### PR TITLE
Update 20190529

### DIFF
--- a/shinyApp/_infoBuilder/altFiles/eml/eml-access.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-access.xsd
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+  xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+  xmlns="eml://ecoinformatics.org/access-2.1.1" 
+  targetNamespace="eml://ecoinformatics.org/access-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+             schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+             schemaLocation="eml-resource.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-access.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: cjones $'
+          '$Date: 2009-03-05 20:08:47 $'
+      '$Revision: 1.83 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-access</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-access module - Access control rules for resources
+            </title>
+            <para>
+              The eml-access module describes the level of access that is
+              to be allowed or denied to a resource for a particular user or 
+              group of users, and can be described independently for metadata 
+              and data.  The eml-access
+              module uses a reference to a particular authentication system
+              to determine the set of principals (users or groups) that can be
+              specified in the access rules.
+              The special principal 'public' can be used to indicate that any
+              user or group has access permission, thereby making
+              it easier to specify that anonymous access is allowed. 
+             </para>
+            <para>        
+              There are two mechanisms for including access control 
+              via the eml-access module: 
+              <orderedlist>
+                <listitem>
+                  <para>
+                    The top-level "eml" element may have an optional 
+                    &lt;access&gt; element that is used to establish the 
+                    default access control for the entire EML package. If 
+                    this access element is omitted from the document, then 
+                    the package submitter should be given full access to the 
+                    package but all other users should be denied all access. 
+                    To allow the package to be publicly viewable, the EML 
+                    author must explicitly include a rule stating so.  Barring 
+                    the existence of a distribution-level &lt;access&gt; element 
+                    (see below), access to data entities will be controlled by 
+                    the package-level &lt;access&gt; element in the 
+                    &lt;eml&gt; element.
+                  </para>
+                </listitem>
+                <listitem>
+                  <para>
+                    Exceptions for particular entity-level components of the 
+                    package can be controlled at a finer grain by using an 
+                    access description in that entity's physical/distribution 
+                    tree. When access control rules are specified at this 
+                    level, they apply only to the data in the parent 
+                    distribution element, and not to the metadata. Thus, it 
+                    will control access to the content of the &lt;inline&gt; 
+                    element, as well as resources that are referenced by the 
+                    &lt;online/url&gt; and &lt;online/connection&gt; paths. 
+                    These exceptions to access for particular data resources 
+                    are applied after the default access rules at the 
+                    package-level have been applied, so they effectively 
+                    override the default rules when they overlap.
+                  </para>
+                </listitem>
+              </orderedlist>
+            </para>
+            <para>
+              In previous versions of EML access rules for entity-level 
+              distribution were contained in &lt;additionalMetadata&gt; 
+              sections and referenced via the &lt;describes&gt; tag. 
+              Although in theory these could have referenced any node, in 
+              application such node-level access control is problematic. 
+              Since the most common uses of access control rules were to 
+              limit access to specific data entities, the access tree has 
+              been placed there explicitly in EML 2.1.0.
+            </para>          
+            <para>
+              Access is specified with a choice of child elements, either 
+              &lt;allow&gt; or &lt;deny&gt;. Within these rules, values can 
+              be assigned for each &lt;principal&gt; using the 
+              &lt;permission&gt; element. Users given &quot;read&quot; permission can 
+              view the resource; &quot;write&quot; allows changes to the resource 
+              excluding changes to the access rules; &quot;changePermission&quot; 
+              includes &quot;write&quot; plus the changing of access rules. Users 
+              allowed &quot;all&quot; permissions; may do all of the above.  Access to 
+              data and metadata is affected by the order attribute of the 
+              &lt;access&gt; element. It is possible for a deny rule to 
+              override an allow rule, and vice versa.  In the case where the 
+              order attribute is set to &quot;allowFirst&quot;, and there are rules 
+              similar to the following (with non-critical sections deleted):
+<literalLayout>
+  &lt;deny&gt;
+    &lt;principal&gt;public&lt;/principal&gt;
+    &lt;permission&gt;read&lt;/permission&gt;
+  &lt;/deny&gt;
+  &lt;allow&gt;
+    &lt;principal&gt;uid=alice,o=NASA,dc=ecoinformatics,dc=org&lt;/principal&gt;
+    &lt;permission&gt;read&lt;/permission&gt;
+  &lt;/allow&gt;
+</literalLayout>
+              the principal &quot;uid=alice ...&quot; will be denied access, 
+              because it is a member of the special &quot;public&quot; 
+              principal, and the deny rule is processed second. For this 
+              allow rule to truly allow access to that principal, the order 
+              attribute should be set to &quot;denyFirst&quot;, and the 
+              allow rule will override the deny rule when it is processed 
+              second.              
+            </para>
+            <para>
+              An example is given below, with non-critical sections deleted:
+<literalLayout>
+  &lt;eml&gt;
+      &lt;access 
+          authSystem="ldap://ldap.ecoinformatics.org:389/dc=ecoinformatics,dc=org" 
+          order="allowFirst"&gt;
+        &lt;allow&gt;
+          &lt;principal&gt;uid=alice,o=NASA,dc=ecoinformatics,dc=org&lt;/principal&gt;
+          &lt;permission&gt;read&lt;/permission&gt;
+          &lt;permission&gt;write&lt;/permission&gt;
+        &lt;allow&gt;
+      &lt;/access&gt;
+      &lt;dataset&gt;
+      ...
+      ...
+      &lt;dataTable id="entity123"&gt;
+      ...
+        &lt;physical&gt;
+        ...
+          &lt;distribution&gt;
+          ...
+            &lt;access id="access123"
+            authSystem="ldap://ldap.ecoinformatics.org:389/dc=ecoinformatics,dc=org" 
+            order="allowFirst"&gt;
+              &lt;deny&gt;
+                &lt;principal&gt;uid=alice,o=NASA,dc=ecoinformatics,dc=org&lt;/principal&gt;
+                &lt;permission&gt;write&lt;/permission&gt;
+            &lt;/deny&gt;
+          &lt;/access&gt;
+         &lt;/distribution&gt;
+       &lt;/physical&gt;
+      &lt;/dataTable&gt;
+      &lt;dataTable id="entity234"&gt;
+        ...
+        &lt;physical&gt;
+        ...
+          &lt;distribution&gt;
+            ...
+            &lt;access&gt;
+              &lt;references&gt;access123&lt;/references&gt;
+            &lt;/access&gt;
+          &lt;/distribution&gt;
+        &lt;/physical&gt;
+      &lt;/dataTable&gt;
+      ...    
+    &lt;/dataset&gt;
+  &lt;eml&gt;
+</literalLayout>
+              In this example, the overall default access is to allow the 
+              user=alice (but no one else) to read and write all metadata 
+              and data. However, under &quot;entity123&quot; and 
+              &quot;entity234&quot;, there is an additional rule saying 
+              that user=alice does not have write permission. The net 
+              effect is that Alice can read and make changes to the 
+              metadata, but cannot make changes to the two data entities. 
+              In addition, Alice cannot change these access rules; although 
+              the submitter can.
+            </para>
+            <para>
+              This example also shows how the eml-access module, like other modules,
+              may be "referenced" via the &lt;references&gt; tag.  This
+              allows an access control document to be described once, and then
+              used as a reference in other locations within the EML document
+              via its ID.
+            </para>
+            <para>
+            In summary, access rules can be applied in two places in an
+            eml document. Default access rules are established
+            in the top &lt;access&gt; element for the main eml document (e.g.,
+            "/eml/access").  These default rules can be overridden
+            for particular data entities by adding additional &lt;access&gt;
+            elements in the physical/distribution trees of those entities.
+           </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all data where controlling user access to the
+        dataset is an issue</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="access" type="AccessType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Access control rules</doc:tooltip>
+        <doc:summary>The rules defined in this element will determine the level
+        of access to a resource for the defined users and groups.</doc:summary>
+        <doc:description>The access element contains a list of rules defining
+        permissions for this resource. For descriptions of the individual elements, 
+        see the AccessType.The permission rules defined here can be overridden 
+         by rules added to an access tree in the PhysicalDistributionType  
+        at the entity level. </doc:description>
+        <doc:example>See the description of the AccessType.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="AccessType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Access control rules</doc:tooltip>
+        <doc:summary>The rules defined in this element will determine the level
+        of access to a resource for the defined users and groups.</doc:summary>
+        <doc:description>The access element contains a list of rules that define
+        the level of access for a resource. There are two uses of access trees: to
+        control access to either metadata or data. To control access to metadata 
+        use the eml/access tree. By default, these rules will also apply to the contained 
+        data. To override the default controls for specific data entities, use the 
+        access element available in the entity's physical/distribution tree.  A 
+        combination of access trees and their "order rules" (see description of 
+        the "order" attribute) allows EML authors
+        to have fine control over permissions for individuals and groups.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="allow" type="AccessRule">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Allow rule</doc:tooltip>
+              <doc:summary>A rule that grants a permission
+              type.</doc:summary>
+              <doc:description>The allow element indicates that a particular
+              user or group is granted the defined permission.</doc:description>
+              <doc:example>allow</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="deny" type="AccessRule">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Deny rule</doc:tooltip>
+              <doc:summary>A rule that revokes a permission
+              type.</doc:summary>
+              <doc:description>The deny element indicates that a particular
+              user or group is not granted the defined
+              permission.</doc:description>
+              <doc:example>deny</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+    <xs:attribute name="order" use="optional" default="allowFirst">
+      <xs:annotation>
+        <xs:appinfo>
+          <doc:tooltip>Rule order</doc:tooltip>
+          <doc:summary>The order in which the allow and deny rules should be
+          applied.</doc:summary>
+          <doc:description>To obtain the desired access control, use the order 
+          attribute to define which rules should be applied first. The acceptable
+          values are 'allowFirst' and 'denyFirst'. If 'allowFirst' is
+          specified, then all 'allow' rules are processed, and then overridden
+          by all 'deny' rules.  If 'denyFirst' is specified, then all 'deny'
+          rules are processed, and then overridden by all 'allow' rules.  
+          </doc:description>
+          <doc:example>allowFirst</doc:example>
+        </xs:appinfo>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="allowFirst"/>
+          <xs:enumeration value="denyFirst"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="authSystem" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:appinfo>
+          <doc:tooltip>Authentication system</doc:tooltip>
+          <doc:summary>The authentication system is used to verify the user or
+          group to whom access is allowed or denied.</doc:summary>
+          <doc:description>The authentication system determines the set of
+          principals (users + groups) that can be used in the access control
+          list, and the membership of users in groups. This element is intended
+          to provide a reference to the authentication system that is used to
+          verify the user or group. This reference is typically in the form
+          of a URI, which includes the connection protocol, Internet host, and
+          path to the authentication mechanism.</doc:description>
+          <doc:example>
+          ldap://ldap.ecoinformatics.org:389/dc=ecoinformatics,dc=org
+          </doc:example>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="AccessRule">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Access Rule</doc:tooltip>
+        <doc:summary>Access Rules define a user's access to a
+        resource.</doc:summary>
+        <doc:description>The AccessRule type defines a list of users that are
+        derived from a particular authentication system (such as an LDAP
+        directory), whether the user or group is allowed or denied access, the
+        extent of their access (read, write , or changePermission
+        access).</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="principal" type="res:NonEmptyStringType" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>User or group</doc:tooltip>
+            <doc:summary>The user or group (principal) for which the access
+            control applies.</doc:summary>
+            <doc:description>The principal element defines the user or group to
+            which the access control rule applies. The users and groups must be
+            defined in the authentication system described in the authSystem
+            element.  The special principal 'public' can be used to indicate
+            that any user or group has a particular access permission, thereby
+            making it easier to specify that anonymous access is allowed.
+            </doc:description>
+            <doc:example>public</doc:example>
+            <doc:example>uid=alice,o=LTER,dc=ecoinformatics,dc=org</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="permission" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Type of permission</doc:tooltip>
+            <doc:summary>The type of permission being granted or denied.
+            </doc:summary>
+            <doc:description>
+              <doc:section xmlns="">
+                <para>
+            The permission that is being granted or denied
+            to a particular user or group for a given resource. The list of
+            permissions come from a predetermined list:
+            </para>
+                <para>'read' - allow or deny viewing of the resource, </para>
+                <para>'write' - allow or deny modification of the resource (except for access rules),  </para>
+                <para>'changePermission' - modifications including access rules, and  </para>
+                <para>'all' - all of the above. </para>
+                <para>
+               
+                This element also allows other permission values that may be applicable to some other authentication systems but are not defined in this specification (if these other values are used, access rule enforcement is indeterminate outside of the originating system).</para>
+              </doc:section>
+            </doc:description>
+            <doc:example>read</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union>
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="read"/>
+                <xs:enumeration value="write"/>
+                <xs:enumeration value="changePermission"/>
+                <xs:enumeration value="all"/>
+              </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+              <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-attribute.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-attribute.xsd
@@ -1,0 +1,1703 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:cit="eml://ecoinformatics.org/literature-2.1.1" xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" xmlns:md="eml://ecoinformatics.org/methods-2.1.1" xmlns="eml://ecoinformatics.org/attribute-2.1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:unit="eml://ecoinformatics.org/units-2.1.1" targetNamespace="eml://ecoinformatics.org/attribute-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/methods-2.1.1" schemaLocation="eml-methods.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/literature-2.1.1" schemaLocation="eml-literature.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/units-2.1.1" schemaLocation="eml-unitTypeDefinitions.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+    '$RCSfile: eml-attribute.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.123 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-attribute</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+            The eml-attribute module - Attribute level information within
+            dataset entities
+          </title>
+            <para>
+            The eml-attribute module describes all attributes (variables)
+            in a data entity: dataTable, spatialRaster, spatialVector,
+            storedProcedure, view or otherEntity. The description includes the
+            name and definition of each attribute, its domain, definitions of
+            coded values, and other pertinent information. Two structures exist
+            in this module: 1.  attribute is used to define a single attribute;
+            2. attributeList is used to define a list of attributes that go
+            together in some logical way.
+          </para>
+            <para>
+            The eml-attribute module, like other modules, may be
+            "referenced" via the &lt;references&gt; tag.  This
+            allows an attribute document to be described once, and then
+            used as a reference in other locations within the EML document
+            via its ID.
+            </para>
+            <section>
+              <title>Philosophy of Attribute Units</title>
+              <para>The concept of "unit" represents one of the most fundamental
+            categories of metadata. The classic example of data entropy is the
+            case in which a reported numeric value loses meaning due to lack of
+            associated units. Much of Ecology is driven by measurement, and
+            most measurements are inherently comparative. Good data description
+            requires a representation of the basis for comparison, i.e., the
+            unit. In modeling the attribute element, the authors of EML drew
+            inspiration from the
+            <ulink url="http://physics.nist.gov/cuu/Units/introduction.html">
+            NIST Reference on Constants, Units, and Uncertainty</ulink>.
+            This document defines a unit as "a particular physical quantity,
+            defined and adopted by convention, with which other particular
+            quantities of the same kind are compared to express their value."
+            The authors of the EML 2.0 specification (hereafter "the authors")
+            decided to make the unit element required, wherever
+            possible.</para>
+              <para>Units may also be one of the most problematic categories of
+            metadata. For instance, there are many candidate attributes that
+            clearly have no units, such as named places and letter grades.
+            There are other candidate attributes for which units are difficult
+            to identify, despite some suspicion that they should exist (e.g.
+            pH, dates, times). In still other cases, units may be meaningful,
+            but apparently absent due to dimensional analysis (e.g. grams of
+            carbon per gram of soil). The relationship between units and
+            dimensions likewise is not completely clear.</para>
+              <para>The authors decided to sharpen the model of attribute by
+            nesting unit under measurementScale. Measurement Scale is a data
+            typology, borrowed from Statistics, that was introduced in the
+            1940's. Under the adopted model, attributes are classified as
+            nominal, ordinal, interval, and ratio. Though widely criticized,
+            this classification is well-known and provides at least first-order
+            utility in EML. For example, nesting unit under measurementScale
+            allows EML to prevent its meaningless inclusion for categorical
+            data -- an approach judged superior to making unit universally
+            required or universally optional.</para>
+              <para>The sharpening of the attribute model allowed the elimination
+            of the unit type "undefined" from the standard unit dictionary (see
+            eml-unitDictionary.xml). It seemed self-defeating to require the
+            unit element exactly where appropriate, yet still allow its content
+            to be undefined. An attribute that requires a unit definition is
+            malformed until one is provided. The unit type "dimensionless" is
+            preserved, however. In EML 2.0, it is synonymous with "unitless"
+            and represents the case in which units cannot be associated with an
+            attribute for some reason, despite the proper classification of
+            that attribute as interval or ratio. Dimensionless may itself be an
+            anomaly arising from the limitations of the adopted measurement
+            scale typology.</para>
+              <para>Closely related to the concept of unit is the concept of
+            attribute domain. The authors decided that a well-formed
+            description of an attribute must include some indication of the set
+            of possible values for that attribute. The set of possible values
+            is useful, perhaps necessary, for interpreting any particular
+            observed value. While universally required, attribute domain has
+            different forms, depending on the associated measurement
+            scale.</para>
+              <para>The element storageType has an obvious relationship to
+            domain. It gives some indication of the range of possible values of
+            an attribute, and also gives some (potentially critical)
+            operability information about the way the attribute is represented
+            or construed in the local storage system. The storageType element
+            seems to fall in a gray area between the logical and physical
+            aspects of stored data. Neither comfortable with eliminating it nor
+            with making it required, the authors left it available but optional
+            under attribute. In addition, it is repeatable so that different 
+            storage types can be provided for various systems (e.g., different
+            databases might use different types for columns, even though the
+            domain of the attribute is the same regardless of which database
+            is used).</para>
+              <para>Attributes representing dates, times, or combinations thereof
+            (hereafter "dateTime") were the most difficult to model in EML. Is
+            dateTime of type interval or ordinal? Does it have units or not?
+            Strong cases can be made on each side of the issue. The confusion
+            may reflect the limitations of the measurement scale typology. The
+            final resolution of the dateTime model is probably somewhat
+            arbitrary. There was clearly a need, however, to allow for the
+            interoperability of dateTime formats. EML 2.0 tries to provide an
+            unambiguous mechanism for describing the format of dateTime
+            values by providing a separate category for date and  time values. This
+            "dateTime" measurement scale allows users to explicitly label 
+            attributes that contain Gregorian date and time values, and allows
+            them to provide the information needed to parse these values into
+            their appropriate components (e.g., days, months, years)./</para>
+            </section>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>any dataset that uses dataTable, spatialRaster,
+        spatialVector, storedProcedure, view or otherEntity or in a custom
+        module where one wants to document an attribute
+        (variable)</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="attribute" type="AttributeType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Attribute</doc:tooltip>
+        <doc:summary>Characteristics of a 'field' or 'variable' in a data
+        entity (ie. dataTable).</doc:summary>
+        <doc:description>The content model for attribute is a CHOICE between
+        "references" and all of the elements that let you describe the
+        attribute (e.g., attributeName, attributeDefinition, precision). The
+        attribute element allows a user to document the characteristics that
+        describe a 'field' or 'variable' in a data entity (e.g. dataTable).
+        Complete attribute descriptions are perhaps the most important aspect
+        to making data understandable to others. An attribute element describes
+        a single attribute or an attribute element can contain a reference
+        to an attribute defined elsewhere. Using a reference means that the
+        referenced attribute is (semantically) identical, not just in name
+        but identical in its complete description. For example, if attribute
+        "measurement1" in dataTable "survey1" has a precision of 0.1 and
+        you are documenting dataTable survey2 which has an attribute called
+        "measurement1" but the survey2's measurement1 has a precision of
+        0.001 then these are different attributes and must be described
+        separately.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="AttributeListType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Attribute List</doc:tooltip>
+        <doc:summary>List of attributes</doc:summary>
+        <doc:description>This complexType defines the structure of the
+        attributeList element. The content model is a choice between one or
+        more attribute elements, and references. References links to an
+        attribute list defined elsewhere.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="attribute" type="AttributeType" maxOccurs="unbounded"/>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="AttributeType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Attribute Type</doc:tooltip>
+        <doc:summary>
+        Type definition for the content of an attribute (variable)
+        that can be part of an entity.
+        </doc:summary>
+        <doc:description> Type definition for the content of an
+        attribute (variable) that can be part of an entity.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="attributeName" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute name</doc:tooltip>
+              <doc:summary>The name of the attribute
+              </doc:summary>
+              <doc:description>Attribute name is official name of the
+              attribute.  This is usually a short, sometimes cryptic name
+              that is used to refer to the attribute.  Many systems have
+              restrictions on the length of attribute names, and on the
+              use of special characters like spaces in the name, so the
+              attribute name is often not particularly useful for display
+              (use attributeLabel for display).  The attributeName is
+              usually the name of the variable that is found in the header
+              of a data file.
+              </doc:description>
+              <doc:example>spden</doc:example>
+              <doc:example>spatialden</doc:example>
+              <doc:example>site</doc:example>
+              <doc:example>spcode</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="attributeLabel" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute label</doc:tooltip>
+              <doc:summary>A label for displaying an attribute name.
+              </doc:summary>
+              <doc:description>A descriptive label that can be used to display
+              the name of an attribute.  This is often a longer, possibly
+              multiple word name for the attribute than the attributeName. It
+              is not constrained by system limitations on length or special
+              characters.  For example, an attribute with a name of 'spcode'
+              might have an attributeLabel of 'Species Code'.
+              </doc:description>
+              <doc:example>Species Density</doc:example>
+              <doc:example>Spatial Density</doc:example>
+              <doc:example>Name of Site</doc:example>
+              <doc:example>Species Code</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="attributeDefinition" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute definition</doc:tooltip>
+              <doc:summary>Precise definition of the attribute
+              </doc:summary>
+              <doc:description>This element gives a precise definition of
+              attribute in the data entity (dataTable, spatialRaster,
+              spatialVector, storedProcedure, view or otherEntity) being
+              documented. It explains the contents of the attribute fully so
+              that a data user could interpret the attribute accurately.
+              Some additional information may also be found in the
+              methods element as well.
+              </doc:description>
+              <doc:example>"spden" is the number of individuals of all
+              macro invertebrate species found in the plot</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="storageType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Storage Type</doc:tooltip>
+              <doc:summary>Storage type hint for this field</doc:summary>
+              <doc:description>This element describes the storage type,
+              for data in a RDBMS (or other data management system) field. 
+              As many systems do not
+              provide for fine-grained restrictions on types, this type will
+              often be a superset of the allowed domain defined in
+              attributeDomain. Values for this field are by default drawn from
+              the XML Schema Datatypes standard values, such as: integer,
+              double, string, etc. If the XML Schema Datatypes are not used,
+              the type system from which the values are derived should be
+              listed in the 'typeSystem' attribute described below. This field
+              represents a 'hint' to processing systems as to how the attribute
+              might be represented in a system or language, but is distinct
+              from the actual expression of the domain of the attribute. The
+              field is repeatable so that the storageType can be indicated for
+              multiple type systems (e.g., Oracle data types and Java data
+              types).</doc:description>
+              <doc:example>integer</doc:example>
+              <doc:example>int</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="typeSystem" type="xs:string" use="optional" default="http://www.w3.org/2001/XMLSchema-datatypes">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Storage Type System</doc:tooltip>
+                      <doc:summary>The system used to define the storage types.
+                      This should be an identifier of a well known and
+                      published typing system.</doc:summary>
+                      <doc:description>The typeSystem attribute is the system
+                      used to define the storage types. This should be an
+                      identifier of a well known and published typing system.
+                      The default and recommended system is the XML Schema data
+                      type system. For details go to http://www.w3.org. If
+                      another system is used (such as Java or C++ types),
+                      typeSystem should be changed to match the
+                      system.</doc:description>
+                      <doc:example>
+                      http://www.w3.org/2001/XMLSchema-datatypes</doc:example>
+                      <doc:example>java</doc:example>
+                      <doc:example>C</doc:example>
+                      <doc:example>Oracle 8i</doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="measurementScale">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Measurement Scale</doc:tooltip>
+              <doc:summary>The measurement scale for the attribute.
+              </doc:summary>
+              <doc:description>The measurementScale element indicates the
+              type of scale from which values are drawn for the
+              attribute. This provides information about the scale in
+              which the data was collected.</doc:description>
+              <doc:example>Nominal is used when numbers have only been assigned
+              to a variable for the purpose of categorizing the
+              variable.  An example of a nominal scale is assigning the
+              number 1 for male and 2 for female.</doc:example>
+              <doc:example>Ordinal is used when the categories have a logical
+              or ordered relationship to each other. These types of scale
+              allow one to distinguish the order of values, but not the
+              magnitude of the difference between values. An example of an
+              ordinal scale is a categorical survey where you rank a variable
+              1=good, 2=fair, 3=poor.</doc:example>
+              <doc:example>Interval is used for data which consist of
+              equidistant points on a scale. The Celsius scale is an interval
+              scale, since each degree is equal but there is no natural
+              zero point (so, 20 C is not twice as hot as 10 C).
+              </doc:example>
+              <doc:example>Ratio is used for data which consists not only of
+              equidistant points but also has a meaningful zero
+              point, which allows ratios to have meaning. An example of a
+              ratio scale would be the Kelvin temperature scale (200K is
+              half as hot as 400K), and length in
+              meters (e.g., 10 meters is twice as long as 5 meters).
+              </doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="nominal">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Nominal scale</doc:tooltip>
+                    <doc:summary>Characteristics used to define nominal 
+                    (categorical) scale attributes</doc:summary>
+                    <doc:description>This field is used for defining the
+                    characteristics of this variable if it is a
+                    nominal scale variable, which are variables that are
+                    categorical in nature.
+                    Nominal is used when numbers have only been
+                    assigned to a variable for the purpose of categorizing the
+                    variable.  An example of a nominal scale is assigning the
+                    number 1 for male and 2 for female.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="nonNumericDomain" type="NonNumericDomainType"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="ordinal">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Ordinal scale</doc:tooltip>
+                    <doc:summary>Characteristics used to define ordinal 
+                    (ordered) scale attributes</doc:summary>
+                    <doc:description>This field is used for defining the
+                    characteristics of this variable if it is an
+                    ordinal scale variable, which specify ordered values
+                    without specifying the magnitude of the difference between
+                    values. Ordinal is used when the categories have
+                    a logical or ordered relationship to each other. These
+                    types of scale allow one to distinguish the order
+                    of values, but not the magnitude of the difference
+                    between values. An example of an ordinal scale is a
+                    categorical survey where you rank a variable 1=good,
+                    2=fair, 3=poor.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="nonNumericDomain" type="NonNumericDomainType"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="interval">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Interval scale</doc:tooltip>
+                    <doc:summary>Characteristics used to define interval 
+                    scale attributes</doc:summary>
+                    <doc:description>This field is used for defining the
+                    characteristics of this variable if it is an
+                    interval scale variable, which specifies both the order
+                    and magnitude of values, but has no natural zero point.
+                    Interval is used for data which consist of
+                    equidistant points on a scale. The Celsius scale is an
+                    interval scale, since each degree is equal but there is
+                    no natural zero point (so, 20 C is not twice as hot as
+                    10 C).  zero point (so, 20 C is not twice as hot as 10
+                    C).</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="unit" type="UnitType"/>
+                    <xs:element name="precision" type="PrecisionType" minOccurs="0"/>
+                    <xs:element name="numericDomain" type="NumericDomainType"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="ratio">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Ratio scale</doc:tooltip>
+                    <doc:summary>Characteristics used to define ratio 
+                    scale attributes</doc:summary>
+                    <doc:description>This field is used for defining the
+                    characteristics of this variable if it is a
+                    ratio scale variable, which specifies the order and
+                    magnitude of values and has a natural zero point, allowing
+                    for ratio comparisons to be valid.
+                    Ratio is used for data which consists not
+                    only of equidistant points but also has a meaningful zero
+                    point, which allows ratios to have meaning. An example
+                    of a ratio scale would be the Kelvin temperature scale
+                    (200K is half as hot as 400K), and length in meters (e.g.,
+                    10 meters is twice as long as 5 meters).</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="unit" type="UnitType"/>
+                    <xs:element name="precision" type="PrecisionType" minOccurs="0"/>
+                    <xs:element name="numericDomain" type="NumericDomainType"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="dateTime">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Date/Time scale</doc:tooltip>
+                    <doc:summary>Characteristics used to define date and 
+                    time attributes</doc:summary>
+                    <doc:description>
+                      <para xmlns="">The dateTime field is used for defining the
+                    characteristics of the attribute if it contains
+                    date and time values. DateTime is used when the values
+                    fall on the Gregorian calendar system.  DateTime values
+                    are special because the have properties of interval
+                    values (most of the time it is legitimate to treat them
+                    as interval values by converting them to a duration from
+                    a fixed point) but they sometimes only behave as ordinals
+                    (because the calendar is not predetermined, for some
+                    dateTime values one can only find out the order of
+                    the points and not the magnitude of the duration 
+                    between those points).  Thus, the dateTime scale provides
+                    the information necessary to properly understand and
+                    parse date and time values without improperly 
+                    labeling them under one of the more traditional scales.</para>
+                      <para xmlns="">Date and time values are unlike any other measured values.  
+                      Note that the dateTime field would not be used if
+              one is recording time durations.  In that case, one should use a
+              standard unit such as seconds, nominalMinute or nominalDay, or a
+              customUnit that defines the unit in terms of its relationship to
+              SI second.</para>
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="formatString" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Date/Time Format</doc:tooltip>
+                          <doc:summary>A format string that describes the
+                          format for a date-time value from the Gregorian
+                          calendar.</doc:summary>
+                          <doc:description>
+                            <para xmlns="">A format string that describes
+                            the format for a dateTime value from the
+                            Gregorian calendar.  DateTime values should be
+                            expressed in a format that conforms to the ISO
+                            8601 standard.  This field allows one to specify
+                            the format string that should be used to decode
+                            the date or time value.  To describe the format
+                            of an attribute containing dateTime values,
+                            construct a string representation of the format
+                            using the following symbols:
+                            </para>
+                            <para xmlns="">
+                              <literalLayout>
+              Y   year
+              M   month
+              W   month abbreviation (e.g., JAN)
+              D   day
+              h   hour
+              m   minute
+              s   second
+              T   time designator (demarcates date and time parts of date-time)
+              Z   UTC designator, indicating value is in UTC time
+              .   indicates a decimal fraction of a unit
+              +/- indicates a positive or negative number,
+                  or a positive or negative time zone adjustment relative to UTC
+              -   indicates a separator between date components
+              A/P am or pm designator
+              </literalLayout>
+                            </para>
+                            <para xmlns="">
+              Any other character in the format string is interpreted as a
+              separator character.  Here are some examples of the format
+              strings that can be constructed.
+              </para>
+                            <para xmlns="">
+                              <literalLayout>
+                                 Format string          Example value
+                                 -------------------    ------------------
+                  ISO Date       YYYY-MM-DD             2002-10-14
+                  ISO Datetime   YYYY-MM-DDThh:mm:ss    2002-10-14T09:13:45
+                  ISO Time       hh:mm:ss               17:13:45
+                  ISO Time       hh:mm:ss.sss           09:13:45.432
+                  ISO Time       hh:mm.mm               09:13.42
+                  Non-standard   DD/MM/YYYY             14/10/2002
+                  Non-standard   MM/DD/YYYY             10/14/2002
+                  Non-standard   MM/DD/YY               10/14/02
+                  Non-standard   YYYY-WWW-DD            2002-OCT-14
+                  Non-standard   YYYYWWWDD              2002OCT14
+                  Non-standard   YYYY-MM-DD hh:mm:ss    2002-10-14 09:13:45
+              </literalLayout>
+                            </para>
+                            <para xmlns="">
+              Some notes about these examples.  First, the ISO 8601 standard is
+              strict about the order of date components and the separators that
+              are legal.  Best practice is to follow the ISO 8601 format
+              precisely.  However, we recognize that existing data contain
+              non-standard dates, and existing equipment (e.g., sensors) may
+              still be producing non-standard dates.  Consequently, we have
+              provided the formatting string with additional characters to
+              describe the date formats. In particular note that the use of a
+              slash (/) to separate date components, a space to separate date
+              and time components, using a twelve-hour time with am/pm
+              designator, and placing any of the components out of
+              descending order is non-standard according to ISO.  Nevertheless,
+              these formats can be described using the format string to
+              accommodate existing data.
+              </para>
+                            <para xmlns="">
+              Decimal dateTime values can be extended by indicating in
+              the format that additional decimals can be used.  Only the final
+              unit (e.g., seconds in a time value) can use the extended digits
+              according to the ISO 8601 standard.  For example, to show
+              indicate that seconds are represented to the nearest 1/1000
+              of a second, the format string would be "hh:mm:ss.sss".
+              Note that this only indicates the number of decimals used to
+              record the value, and not the precision of the measurement
+              (see dateTimePrecision for that).
+              </para>
+                            <para xmlns="">
+              Date and time values are from an interval scale, but it is extremely
+              complex because of the vagaries of the calendar (e.g., leap
+              years, and leap seconds).  The duration between date and time values
+              in the future is not even deterministic because leap seconds are
+              based on current measurements of the earth's orbit. Consequently,
+              date and time values are unlike any other measured values.  The format
+              string for dateTime values allows one to accurately calculate the
+              duration in SI second units between two measured dateTime values,
+              assuming that the conversion software has a detailed knowledge of
+              the Gregorian calendar. 
+              </para>
+                          </doc:description>
+                          <doc:example>YYYY-MM-DDThh:mm:ss</doc:example>
+                          <doc:example>YYYY-MM-DD</doc:example>
+                          <doc:example>YYYY</doc:example>
+                          <doc:example>hh:mm:ss</doc:example>
+                          <doc:example>hh:mm:ss.sss</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="dateTimePrecision" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>DateTime Precision</doc:tooltip>
+                          <doc:summary>An indication of the precision of a
+                          date or time value</doc:summary>
+                          <doc:description>A quantitative indication of
+                          the precision of a date or time measurement.
+                          The precision should be interpreted in the
+                          smallest units represented by the dateTime format.
+                          For example, if a dateTime value has a format of
+                          "hh:mm:ss.sss", then "seconds" are the smallest unit
+                          and the precision should be expressed in seconds.
+                          Thus, a precision value of "0.01" would mean that
+                          measurements were precise to the nearest hundredth
+                          of a second, even though the format string might
+                          indicate that values were written down with 3
+                          decimal places.</doc:description>
+                          <doc:example>0.1</doc:example>
+                          <doc:example>0.01</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="dateTimeDomain" type="DateTimeDomainType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>DateTime Domain</doc:tooltip>
+                          <doc:summary>See the summary for the type: DateTimeDomainType</doc:summary>
+                          <doc:description>See the description for the type: DateTimeDomainType</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="missingValueCode" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Character for missing value</doc:tooltip>
+              <doc:summary>Character for missing value in the data of the
+              field</doc:summary>
+              <doc:description>This element is to specify missing value in the
+              data of the field. It is repeatable to allow for multiple
+              different codes to be present in the attribute. Note that missing
+              value codes should not be considered when determining if the
+              observed values of an attribute all fall within the domain
+              of the attribute (i.e., missing value codes should be parsed out
+              of the data stream before examining the data for domain
+              violations.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="code" type="res:NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>The missing value code itself.</doc:tooltip>
+                    <doc:summary>The missing value code itself.</doc:summary>
+                    <doc:description>The code element is the missing value code
+                    itself. Each missing value code should be entered in a
+                    separate element instance. The value entered is what is
+                    placed into a data grid if the value is missing for some
+                    reason.</doc:description>
+                    <doc:example>-9999</doc:example>
+                    <doc:example>-1</doc:example>
+                    <doc:example>N/A</doc:example>
+                    <doc:example>MISSING</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="codeExplanation" type="res:NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Explanation of Missing value Code</doc:tooltip>
+                    <doc:summary>An explanation of what the missing value code
+                    means.</doc:summary>
+                    <doc:description>The codeExplanation element is an
+                    explanation of the meaning of the missing value code that
+                    was used, that is, the reason that there is a missing
+                    value. For example, an attribute might have a missing
+                    value code of '-99' to indicate that the data observation
+                    was not actually taken, and a code of '-88' to indicate
+                    that the data value was removed because of
+                    calibration errors.</doc:description>
+                    <doc:example>Sensor down time.</doc:example>
+                    <doc:example>Technician error.</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="accuracy" type="Accuracy" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>The accuracy of the measured attribute</doc:tooltip>
+              <doc:summary>The accuracy of the attribute. This information
+              should describe any accuracy information that is known about the
+              collection of this data attribute.</doc:summary>
+              <doc:description>The accuracy element represents the accuracy of
+              the attribute. This information should describe any accuracy
+              information that is known about the collection of this data
+              attribute. The content model of this metadata is taken directly
+              from FGDC FGDC-STD-001-1998 section 2 with the exception of
+              processContact, sourceCitation, and timePeriodInformation which
+              either user XMLSchema types or use predefined EML types for these
+              purposes.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="coverage" type="cov:Coverage" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute coverage</doc:tooltip>
+              <doc:summary>An explanation of the coverage of the attribute.
+              </doc:summary>
+              <doc:description>An explanation of the coverage of the attribute.
+              This specifically indicates the spatial, temporal, and taxonomic
+              coverage of the attribute in question when that coverage deviates
+              from coverages expressed at a higher level (e.g., entity or
+              dataset).  Please see the eml-coverage module for complete
+              documentation.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="methods" type="md:MethodsType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute methods</doc:tooltip>
+              <doc:summary>An explanation of the methods involved in the
+              collection of this attribute.</doc:summary>
+              <doc:description>An explanation of the methods involved in the
+              collection of this attribute. These specifically supplement or
+              possibly override methods provided at a higher level such as
+              entity or dataset.
+              Please see the eml-methods module for complete documentation.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="Accuracy">
+    <xs:sequence>
+      <xs:element name="attributeAccuracyReport" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Attribute Accuracy Report</doc:tooltip>
+            <doc:summary>An explanatory report of the accuracy of the
+            attribute.</doc:summary>
+            <doc:description>The attributeAccuracyReport element is an
+            explanation of the accuracy of the observation recorded in this
+            attribute. It will often include a description of the tests used to
+            determine the accuracy of the observation. These reports are
+            generally prepared for remote sensing or other measurement
+            devices.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="quantitativeAttributeAccuracyAssessment" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Quantitative Attribute Accuracy
+            Assessment</doc:tooltip>
+            <doc:summary>A value assigned to summarize the accuracy of the
+            attribute.</doc:summary>
+            <doc:description>The quantitativeAttributeAccuracyAssessment
+            element is composed of two parts, a value that represents the
+            accuracy of the recorded observation an explanation of the tests
+            used to determine the accuracy.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="attributeAccuracyValue" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Attribute Accuracy Value</doc:tooltip>
+                  <doc:summary>A value assigned to estimate the accuracy of the
+                  attribute.</doc:summary>
+                  <doc:description>The attributeAccuracyValue element is an
+                  estimate of the accuracy of the identification of the
+                  entities and assignments of attribute values in the data set.
+                  </doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="attributeAccuracyExplanation" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Attribute Accuracy Explanation</doc:tooltip>
+                  <doc:summary>The test which yields the Attribute Accuracy
+                  Value.</doc:summary>
+                  <doc:description>The attributeAccuracyExplanation element is
+                  the identification of the test that yielded the Attribute
+                  Accuracy Value.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="attributeList" type="AttributeListType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Attribute list</doc:tooltip>
+        <doc:summary>A list of attributes</doc:summary>
+        <doc:description>This is the root element of the eml-attribute module.
+        It is mainly used for testing, but can also be used for creating
+        stand-alone eml-attribute modules where a list of attributes is
+        needed.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="UnitType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Unit of measurement</doc:tooltip>
+        <doc:summary>Unit of measurement for data in the
+        field</doc:summary>
+        <doc:description>This field identifies the unit of measurement
+        for this attribute. It is a choice of either a standard unit,
+        or a custom unit. If it is a custom unit,
+        the definition of the unit must be provided in the document using
+        the STMML syntax, and the name provided in the customUnit element must
+        reference the id of its associated STMML definition precisely. For
+        further information on STMML (http://www.xml-cml.org/stmml/) or
+        see stmml.xsd which is included with the EML 2.0 distribution for
+        details.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="standardUnit" type="unit:StandardUnitDictionary">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Standard Unit</doc:tooltip>
+            <doc:summary>The name of a standard unit used to make this
+            measurement</doc:summary>
+            <doc:description>Use the standardUnit element if the unit for this attribute has 
+            been defined in the Standard Unit Dictionary.
+            The list of "standard" units includes the SI base units and many compound units based
+            on SI, plus and some commonly used units which are not SI. The list is by no means
+            exhaustive. If the unit you need is not part of this list, then the customUnit field should be used
+            instead. Standard units have been described using STMML. See the documentation
+            for the Type for more information.</doc:description>
+            <doc:example>meter</doc:example>
+            <doc:example>second</doc:example>
+            <doc:example>joule</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="customUnit" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Custom Unit</doc:tooltip>
+            <doc:summary>The name of a custom unit used to make this
+            measurement.</doc:summary>
+            <doc:description>The customUnit element is for units that are
+             not part of the standard list provided with EML. The customUnit 
+             must correspond to an id in the
+            document where its definition is provided using the STMML
+            syntax. The customUnit definition will most likely be in
+            the additionalMetadata section.</doc:description>
+            <doc:example>gramsPerOneThirdMeter</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+  <xs:complexType name="PrecisionType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Precision</doc:tooltip>
+        <doc:summary>The precision of the measurement.</doc:summary>
+        <doc:description>Precision indicates how close together or how 
+        repeatable measurements are.  A precise measuring instrument will give 
+        very nearly the same result each time it is used. This means that 
+        someone interpreting the data should expect that if a measurement were 
+        repeated, most measured values would fall within the interval specified 
+        by the precision. The value of precision should be expressed in the
+        same unit as the measurement. For example, for an attribute with unit 
+        "meter", a precision of "0.1" would be interpreted to mean that most 
+        repeat measurements would fall within an interval of 1/10th of a meter.
+        </doc:description>
+        <doc:example>0.1</doc:example>
+        <doc:example>0.5</doc:example>
+        <doc:example>1</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:float"/>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="NonNumericDomainType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Non-numeric domain</doc:tooltip>
+        <doc:summary/>
+        <doc:description>The non-numeric domain field describes the domain
+        of the attribute being documented.  It can describe two
+        different types of domains: enumerated and text.  Enumerated
+        domains are lists of values that are explicitly provided as
+        legitimate values.  Only values from that list should occur
+        in the attribute.  They are often used for response codes
+        such as "HIGH" and "LOW".  Text domains are used for attributes
+        that allow more free-form text fields, but still permit some
+        specification of the value-space through pattern matching.  A
+        text domain is usually used for comment and notes attributes,
+        and other character attributes that don't have a precise set of
+        constrained values. This is an important field for post processing
+        and error checking of the dataset. It represents a formal 
+        specification of the value space for the attribute, and so there 
+        should never be a value for the attribute that falls outside of 
+        the set of values prescribed by the domain.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="enumeratedDomain">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Enumerated domain</doc:tooltip>
+              <doc:summary>Description of any coded values associated
+              with the attribute.</doc:summary>
+              <doc:description>The enumeratedDomain element describes
+              any code that is used as a value of an attribute. These
+              codes can be defined here in the metadata as a list with
+              definitions (preferred), can be referenced by pointing to
+              an external citation or URL where the codes are defined,
+              or can be referenced by pointing at an entity that contains
+              the code value and code definition as two attributes. For
+              example, data might have a variable named 'site' with
+              values 'A', 'B', and 'C', and the enumeratedDomain would
+              explain how to interpret those codes.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="codeDefinition" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Code Definition</doc:tooltip>
+                    <doc:summary>A codes and its definition</doc:summary>
+                    <doc:description>This element gives the value of a
+                    particular code and its definition.  It is repeatable
+                    to allow for a list of codes to be provided.
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="code" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Code</doc:tooltip>
+                          <doc:summary>Code value allowed in the
+                          domain</doc:summary>
+                          <doc:description>The code element specifies a
+                          code value that can be used in the domain
+                          </doc:description>
+                          <doc:example>1</doc:example>
+                          <doc:example>HIGH</doc:example>
+                          <doc:example>BEPA</doc:example>
+                          <doc:example>24</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="definition" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Code definition</doc:tooltip>
+                          <doc:summary>Definition of the associated code
+                          </doc:summary>
+                          <doc:description>The definition describes the
+                          code with which it is associated in enough 
+                          detail for scientists to interpret the meaning
+                          of the coded values.</doc:description>
+                          <doc:example>high density, above 10 per square 
+                          meter</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="source" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Source of code</doc:tooltip>
+                          <doc:summary>The name of the source for this
+                          code and its definition</doc:summary>
+                          <doc:description>The source element is the name
+                          of the source from which this code and its
+                          associated definition are drawn. This is
+                          commonly used for identifying standard coding
+                          systems, like the FIPS standard for postal
+                          abbreviations for states in the US. In other
+                          cases, the coding may be the researcher's
+                          customized way of recording and classifying
+                          their data, and no external "source" would
+                          exist.</doc:description>
+                          <doc:example>ISO country codes</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="order" type="xs:long" use="optional">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Order</doc:tooltip>
+                        <doc:summary>Mechanism for specifying what the 
+			order of the code-definitions included should 
+			be</doc:summary>
+                        <doc:description>Ordinal scale measurements have a discrete list 
+			of values with a specific ordering of those values. This attributes 
+			specifies that order from low to high. For example, for LOW, 
+            MEDIUM, HIGH, the order attribute might be "LOW=1, MEDIUM=2 and 
+            HIGH=3".
+                  	</doc:description>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="externalCodeSet">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>External code set</doc:tooltip>
+                    <doc:summary>A reference to an externally defined set
+                    of codes used in this attribute</doc:summary>
+                    <doc:description>The externalCodeSet element is a
+                    reference to an externally defined set of codes used
+                    in this attribute. This can either be a citation
+                    (using the eml-citation module) or a
+                    URL. Using an externally defined codeset (rather
+                    than a codeDefinition) means that interpretation of the
+                    data is dependent upon future users being able to
+                    obtain the code definitions, so care should be taken
+                    to only use highly standardized external code sets that
+                    will be available for many years.  If at all possible,
+                    it is preferable to define the codes inline using the
+                    codeDefinition element.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="codesetName" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Code Set Name</doc:tooltip>
+                          <doc:summary>The name of an externally defined
+                          code set</doc:summary>
+                          <doc:description>The codesetName element is the
+                          name of an externally defined code
+                          set.</doc:description>
+                          <doc:example>FIPS State Abbreviation
+                          Codes</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:choice maxOccurs="unbounded">
+                      <xs:element name="citation" type="cit:CitationType">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Citation</doc:tooltip>
+                            <doc:summary>A citation for the code set
+                            reference</doc:summary>
+                            <doc:description>The citation element is a
+                            citation for the code set
+                            reference</doc:description>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:element>
+                      <xs:element name="codesetURL" type="xs:anyURI">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Code set URL</doc:tooltip>
+                            <doc:summary>A URL for the code set
+                            reference</doc:summary>
+                            <doc:description>The codesetURL element is a
+                            URL for the code set
+                            reference.</doc:description>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:element>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="entityCodeList">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Entity Code List</doc:tooltip>
+                    <doc:summary>A code list that is defined in a data
+                    table</doc:summary>
+                    <doc:description>The entityCodeList is a list of
+                    codes and their definitions in a data
+                    entity that is present in this dataset. The fields
+                    specify exactly which entity it is, and which 
+                    attributes of that entity contain the codes, their
+                    definitions, and the order of the values.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="entityReference" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Entity Reference</doc:tooltip>
+                          <doc:summary>A reference to the id of the
+                          entity in which the code list has been
+                          defined</doc:summary>
+                          <doc:description>The entityReference element is
+                          a reference to the id of the entity in which
+                          the code list has been defined. This entity
+                          must have been defined elsewhere in the
+                          metadata and have an id that matches the value
+                          of this element.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="valueAttributeReference" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Value Attribute
+                          Reference</doc:tooltip>
+                          <doc:summary>A reference to the id of the
+                          attribute that contains the list of
+                          codes</doc:summary>
+                          <doc:description>The valueAttributeReference
+                          element is a reference to the id of the
+                          attribute that contains the list of codes. This
+                          attribute must have been defined elsewhere in
+                          the metadata and have an id that matches the
+                          value of this element.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="definitionAttributeReference" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Definition Attribute
+                          Reference</doc:tooltip>
+                          <doc:summary>A reference to the id of the
+                          attribute that contains the definition of
+                          codes</doc:summary>
+                          <doc:description>The
+                          definitionAttributeReference element is a
+                          reference to the id of the attribute that
+                          contains the definition of codes. This
+                          attribute must have been defined elsewhere in
+                          the metadata and have an id that matches the
+                          value of this element.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="orderAttributeReference" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Order Attribute
+                          Reference</doc:tooltip>
+                          <doc:summary>A reference to the id of the
+                          attribute that contains the order of
+                          codes</doc:summary>
+                          <doc:description>The orderAttributeReference element
+                          is a reference to the id of the attribute that
+                          contains the order of codes. The values in this
+                          attribute are integers indicating increasing values
+                          of the categories.  This attribute must have been
+                          defined elsewhere in the metadata and have an id that
+                          matches the value of this element.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="enforced" use="optional" default="yes">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Enforced Domain</doc:tooltip>
+                  <doc:summary>Indicates whether the enumerated
+                  domain values enforced.</doc:summary>
+                  <doc:description>Indicates whether the enumerated
+                  domain values are the only allowable values for
+                  the domain.  In some exceedingly rare cases, users may
+                  wish to present a list of value codes in
+                  enumeratedDomain but not formally restrict the value
+                  space for the attribute to those values.  If so, they
+                  can indicate this by setting the enforced attribute
+                  to the value no.  Acceptable values are yes and no, and
+                  the default value is yes.
+                  </doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="yes"/>
+                  <xs:enumeration value="no"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="textDomain">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Text domain</doc:tooltip>
+              <doc:summary>Description of a free-text domain pattern for
+              the attribute</doc:summary>
+              <doc:description>The textDomain element describes a free
+              text domain for the attribute. By default, if a pattern is
+              missing or empty, then any text is allowed. If a pattern is
+              present, then it is interpreted as a regular expression
+              constraining the allowable character sequences for the
+              attribute. This domain type is most useful for describing
+              extensive text domains that match a pattern but do not
+              have a finite set of values.  Another use is for
+              describing the domain of textual fields like comments
+              that allow any legal string value.</doc:description>
+              <doc:example>Typically, a text domain will have an empty
+              pattern or one that constrains allowable values. For
+              example, '[0-9]{3}-[0-9]{3}-[0-9]{4}' allows for only
+              numeric digits in the pattern of a US phone
+              number.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="definition" type="res:NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Text domain definition</doc:tooltip>
+                    <doc:summary>Definition of what this text domain
+                    represents</doc:summary>
+                    <doc:description>The element definition provides the
+                    text domain definition, that is, what kinds of text
+                    expressions are allowed for this attribute. If there
+                    is a pattern supplied, the definition element
+                    expresses the meaning of the pattern, For example, a
+                    particular pattern may be meant to represent phone
+                    numbers in the US phone system format. A definition
+                    element may also be used to extend an enumerated
+                    domain.</doc:description>
+                    <doc:example>US telephone numbers in the format
+                    "(999) 888-7777"</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="pattern" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Text pattern</doc:tooltip>
+                    <doc:summary>Regular expression pattern constraining
+                    the attribute</doc:summary>
+                    <doc:description>The pattern element specifies a
+                    regular expression pattern that constrains the set of
+                    allowable values for the attribute. This is commonly
+                    used to define template patterns for data such as
+                    phone numbers where the attribute is text but the
+                    values are not drawn from an enumeration. If the
+                    pattern field is empty or missing, it defaults to
+                    '.*', which matches any string, including the empty
+                    string. Repeated pattern elements are combined using
+                    logical OR. The regular expression syntax is the same
+                    as that used in the XML Schema Datatypes
+                    Recommendation from the W3C.</doc:description>
+                    <doc:example>'[0-9a-zA-Z]' matches simple
+                    alphanumeric strings and '(\d\d\d) \d\d\d-\d\d\d\d'
+                    represents telephone strings in the US of the form
+                    '(704) 876-1734'</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="source" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Source of text domain</doc:tooltip>
+                    <doc:summary>The name of the source for this text
+                    domain.</doc:summary>
+                    <doc:description>The source element is the name of
+                    the source from which this text domain and its
+                    associated definition are drawn. This is commonly
+                    used for identifying standard coding systems, like
+                    the FIPS standard for postal abbreviations for states
+                    in the US. In other cases, the coding may be a
+                    researcher's custom way of recording and classifying
+                    their data, and no external "source" would
+                    exist.</doc:description>
+                    <doc:example>ISO country codes</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="NumericDomainType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Numeric Domain</doc:tooltip>
+        <doc:summary>Numeric domain of attribute specifying allowed
+        values.</doc:summary>
+        <doc:description>The numericDomain element specifies the
+        minimum and maximum values of a numeric attribute. These
+        are theoretical or permitted values (ie. prescriptive), and
+        not necessarily the actual minimum and maximum observed in
+        a given data set (descriptive). The information in
+        numericDomain and in precision together constitute
+        sufficient information to decide upon an appropriate
+        system specific data type for representing a particular
+        attribute. For example, an attribute with a numeric domain
+        from 0-50,000 and a precision of 1 could be represented in
+        the C language using a 'long' value, but if the precision is
+        changed to '0.5' then a 'float' type would be needed.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="numberType" type="NumberType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>number type</doc:tooltip>
+              <doc:documentation>The type of number recorded in
+              this attribute.  Values can be 'whole', 'natural',
+              'integer' or 'real'.</doc:documentation>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:group ref="BoundsGroup"/>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="DateTimeDomainType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>DateTime Domain</doc:tooltip>
+        <doc:summary>DateTime domain of attribute specifying allowed
+        values.</doc:summary>
+        <doc:description>The DateTimeDomain specifies the
+        minimum and maximum values of a dateTime attribute. These
+        are theoretical or permitted values (ie. prescriptive), and
+        not necessarily the actual minimum and maximum observed in
+        a given data set (descriptive). The domain expressions should
+        be in the same dateTime format as is used in the "formatString"
+        description for the attribute.  For example, if the format
+        string is "YYYY-MM-DD", then a valid minimum in the domain
+        would be "2001-05-29".  The "bounds" element is optional, and
+        if it is missing then any legitimate value from the Gregorian 
+        calendar system is allowed in the attribute as long as its
+        representation matches its corresponding formatString.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="BoundsDateGroup"/>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+  </xs:complexType>
+  <xs:group name="BoundsGroup">
+     <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Bounds</doc:tooltip>
+        <doc:summary>Elements for specifying allowed
+        values range.</doc:summary>
+        <doc:description>The bounds element contains the
+        minimum and maximum values of a numeric attribute. These
+        are theoretical or permitted values (ie. prescriptive), and
+        not necessarily the actual minimum and maximum observed in
+        a given data set (descriptive). 
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="bounds" minOccurs="0" maxOccurs="unbounded">
+           <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Bounds</doc:tooltip>
+        <doc:summary>Elements for specifying allowed
+        values range.</doc:summary>
+        <doc:description>The bounds element in the BoundsGroup contains the
+        minimum and maximum values of a numeric attribute. These
+        are theoretical or permitted values (ie. prescriptive), and
+        not necessarily the actual minimum and maximum observed in
+        a given data set (descriptive). Either or both a minimum and maximum may 
+        be set, and each has an attribute "exclusive" to define how the value should
+        be interpreted.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="minimum" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Minimum numeric bound</doc:tooltip>
+                  <doc:summary>Minimum numeric bound of
+                attribute</doc:summary>
+                  <doc:description>The minimum element specifies the
+                minimum permitted value of a numeric
+                attribute.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:float">
+                    <xs:attribute name="exclusive" type="xs:boolean" use="required">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Exclusive
+                        </doc:tooltip>
+                          <doc:summary>Exclusive bounds flag
+                        </doc:summary>
+                          <doc:description>If exclusive is set to true, then
+                        the value specifies a lower bound not including
+                        the value itself.  Setting exclusive to true is
+                        the equivalent of using a less-than or greater-than
+                        operator, while setting it to false is the same as
+                        using a less-than-or-equals or greater-than-or-equals
+                        operator. For example, if the minimum is "5" and
+                        exclusive is false, then all values must be greater
+                        than or equal to 5, but if exclusive is true than
+                        all values must be greater than 5 (not including
+                        5.0 itself).
+                        </doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="maximum" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Maximum numeric bound</doc:tooltip>
+                  <doc:summary>Maximum numeric bound of
+                attribute</doc:summary>
+                  <doc:description>The maximum element specifies the
+                maximum permitted value of a numeric
+                attribute.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:float">
+                    <xs:attribute name="exclusive" type="xs:boolean" use="required">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Exclusive
+                        </doc:tooltip>
+                          <doc:summary>Exclusive bounds flag
+                        </doc:summary>
+                          <doc:description>If exclusive is set to true, then
+                        the value specifies a lower bound not including
+                        the value itself.  Setting exclusive to true is
+                        the equivalent of using a less-than or greater-than
+                        operator, while setting it to false is the same as
+                        using a less-than-or-equals or greater-than-or-equals
+                        operator. For example, if the minimum is "5" and
+                        exclusive is false, then all values must be greater
+                        than or equal to 5, but if exclusive is true than
+                        all values must be greater than 5 (not including
+                        5.0 itself).
+                        </doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="BoundsDateGroup">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>BoundsDateGroup</doc:tooltip>
+        <doc:summary>Elements for specifying allowed
+        value ranges.</doc:summary>
+        <doc:description>The BoundsDateGroup specifies the
+        minimum and maximum dates allowed for a dateTime attribute. These
+        are theoretical or permitted values (ie. prescriptive), and
+        not necessarily the actual minimum and maximum observed in
+        a given data set (descriptive). The domain expressions should
+        be in the same dateTime format as is used in the attribute's "formatString".
+        For example, if the format
+        string is "YYYY-MM-DD", then a valid minimum in the domain
+        would be "2001-05-29".  The "bounds" element is optional, and
+        if it is missing then any legitimate value from the Gregorian 
+        calendar system is allowed in the attribute as long as its
+        representation matches its corresponding formatString.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="bounds" minOccurs="0" maxOccurs="unbounded">
+               <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Bounds</doc:tooltip>
+        <doc:summary>Elements for specifying allowed
+        date range.</doc:summary>
+        <doc:description>The bounds element in the BoundsDateGroup contains the
+        minimum and maximum dates of a dateTime attribute. These
+        are theoretical or permitted values (ie. prescriptive), and
+        not necessarily the actual minimum and maximum observed in
+        a given data set (descriptive). Either or both a minimum and maximum may 
+        be set, and each has an attribute "exclusive" to define how the value should
+        be interpreted.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="minimum" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Minimum date bound</doc:tooltip>
+                  <doc:summary>Minimum date bound of
+                attribute</doc:summary>
+                  <doc:description>The minimum element specifies the
+                minimum permitted value of a date
+                attribute.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="exclusive" type="xs:boolean" use="required">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Exclusive
+                        </doc:tooltip>
+                          <doc:summary>Exclusive bounds flag
+                        </doc:summary>
+                          <doc:description>If exclusive is set to true, then
+                        the value specifies a lower bound not including
+                        the value itself.  Setting exclusive to true is
+                        the equivalent of using a less-than or greater-than
+                        operator, while setting it to false is the same as
+                        using a less-than-or-equals or greater-than-or-equals
+                        operator. For example, if the minimum is "5" and
+                        exclusive is false, then all values must be greater
+                        than or equal to 5, but if exclusive is true than
+                        all values must be greater than 5 (not including
+                        5.0 itself).
+                        </doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="maximum" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Maximum date bound</doc:tooltip>
+                  <doc:summary>Maximum date bound of
+                attribute</doc:summary>
+                  <doc:description>The maximum element specifies the
+                maximum permitted value of a date
+                attribute.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="exclusive" type="xs:boolean" use="required">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Exclusive
+                        </doc:tooltip>
+                          <doc:summary>Exclusive bounds flag
+                        </doc:summary>
+                          <doc:description>If exclusive is set to true, then
+                        the value specifies a lower bound not including
+                        the value itself.  Setting exclusive to true is
+                        the equivalent of using a less-than or greater-than
+                        operator, while setting it to false is the same as
+                        using a less-than-or-equals or greater-than-or-equals
+                        operator. For example, if the minimum is "5" and
+                        exclusive is false, then all values must be greater
+                        than or equal to 5, but if exclusive is true than
+                        all values must be greater than 5 (not including
+                        5.0 itself).
+                        </doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="NumberType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:description>This is the enumeration for the allowed values
+        of the element numberType.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="natural">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Natural numbers</doc:tooltip>
+            <doc:summary>Natural numbers
+            </doc:summary>
+            <doc:description>The number type for this attribute consists
+            of the 'natural' numbers, otherwise known as the counting numbers:
+            1, 2, 3, 4, ...
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="whole">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Whole numbers</doc:tooltip>
+            <doc:summary>Whole numbers
+            </doc:summary>
+            <doc:description>The number type for this attribute consists
+            of the 'whole' numbers, which are the natural numbers plus the
+            zero value: 0, 1, 2, 3, 4, ...
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="integer">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Integer numbers</doc:tooltip>
+            <doc:summary>Integer numbers
+            </doc:summary>
+            <doc:description>The number type for this attribute consists
+            of the 'integer' numbers, which are the natural numbers, plus the
+            zero value, plus the negatives of the natural numbers: ..., -4, -3, 
+            -2, -1, 0, 1, 2, 3, 4, ...
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="real">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Real numbers</doc:tooltip>
+            <doc:summary>Real numbers
+            </doc:summary>
+            <doc:description>The number type for this attribute consists
+            of the 'real' numbers, which contains both the rational numbers
+            that can be expressed as fractions and the irrational numbers 
+            that can not be expressed as fractions (such as the square root of 2).
+            </doc:description>
+            <doc:example>4.1516</doc:example>
+            <doc:example>2.5</doc:example>
+            <doc:example>.3333333...</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-constraint.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-constraint.xsd
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns="eml://ecoinformatics.org/constraint-2.1.1" 
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/constraint-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+  schemaLocation="eml-resource.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+               '$RCSfile: eml-constraint.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.53 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-constraint</doc:moduleName>
+        <doc:moduleDescription>
+        <section xmlns="">
+          <title>
+            The eml-constraint module - Relationships among and within
+            dataset entities
+          </title>
+          <para>
+            The eml-constraint schema defines the integrity constraints
+            between entities (e.g., data tables) as they would be maintained in
+            a relational management system.  These constraints include primary
+            key constraints, foreign key constraints, unique key constraints,
+            check constraints, and not null constraints, among potential others.
+          </para>
+        </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>All datasets where there are logical constraints
+        between entities</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:complexType name="ConstraintType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Relational integrity constraint descriptors</doc:tooltip>
+        <doc:summary>Describes the relational integrity constraints of a
+        relational database.</doc:summary>
+        <doc:description>The ConstraintType type describes the relational
+        integrity constraints of a relational database. This includes primary
+        keys, foreign keys, unique keys, etc. When an eml-constraint module is
+        created, it should be linked into a dataset using the "triple" element,
+        and all of the entities that are referenced in the constraints should be
+        accessible within that same package.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="primaryKey">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Primary Key</doc:tooltip>
+            <doc:summary>The primary key in the entity</doc:summary>
+            <doc:description>The primaryKey element declares the primary key in
+            the entity to which the defined constraint
+            pertains.</doc:description>
+            <doc:example>date</doc:example>
+            <doc:example>site</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ConstraintBaseGroup"/>
+            <xs:element name="key">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Key</doc:tooltip>
+                  <doc:summary>The set of attributes to which this constraint
+                  applies.</doc:summary>
+                  <doc:description>The key element defines the set of attributes
+                  to which this constraint applies. For a primary key or a
+                  unique key, the set of attributes must be identifying. For a
+                  foreign key, the set of attributes must match an identifying
+                  key in the referenced entity. For a 'not null' constraint, the
+                  key indicates the attribute which should not be
+                  null.</doc:description>
+                  <doc:example>site</doc:example>
+                  <doc:example>plot</doc:example>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="attributeReference" type="res:NonEmptyStringType" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Attribute Reference</doc:tooltip>
+                        <doc:summary>The identifier of an attribute found
+                        in the identified entity</doc:summary>
+                        <doc:description>The attributeReference element is the
+                        identifier of an attribute that can be found in the
+                        identified entity. This id will be unique within an
+                        entity and specifies that the attribute participates
+                        in the key that is being defined.</doc:description>
+                        <doc:example>site</doc:example>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="uniqueKey">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Unique Key</doc:tooltip>
+            <doc:summary>A unique key in the entity</doc:summary>
+            <doc:description>The uniqueKey element represents a unique key
+            within the referenced entity. This is different from a primary key
+            in that it does not form any implicit foreign key relationships to
+            other entities, however it is required to be unique within the
+            entity.</doc:description>
+            <doc:example>date</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ConstraintBaseGroup"/>
+            <xs:element name="key">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Key</doc:tooltip>
+                  <doc:summary>The set of attributes to which this constraint
+                  applies.</doc:summary>
+                  <doc:description>The key element defines the set of attributes
+                  to which this constraint applies. For a primary key or a
+                  unique key, the set of attributes must be identifying. For a
+                  foreign key, the set of attributes must match an identifying
+                  key in the referenced entity. For a 'not null' constraint, the
+                  key indicates the attribute which should not be
+                  null.</doc:description>
+                  <doc:example>date, site, plot</doc:example>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="attributeReference" type="res:NonEmptyStringType" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Attribute Reference</doc:tooltip>
+                        <doc:summary>The identifier of an attribute found
+                        in the identified entity</doc:summary>
+                        <doc:description>The attributeReference element is the
+                        identifier of an attribute that can be found in the
+                        identified entity. This id will be unique within an
+                        entity and specifies that the attribute participates
+                        in the key that is being defined.</doc:description>
+                        <doc:example>site</doc:example>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="checkConstraint">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Check Constraint</doc:tooltip>
+            <doc:summary>A constraint which checks a conditional clause
+            within an entity.</doc:summary>
+            <doc:description>The checkConstraint element defines a constraint
+            which checks a conditional clause within an
+            entity.</doc:description>
+            <doc:example>if site&gt;1 then plot&gt;10</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ConstraintBaseGroup"/>
+            <xs:element name="checkCondition" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Check Condition</doc:tooltip>
+                  <doc:summary>An SQL statement or other language
+                  implementation of the condition for a check
+                  constraint.</doc:summary>
+                  <doc:description>The checkCondition element defines an SQL
+                  statement or other language implementation of the condition
+                  for a check constraint.  Generally this provides a means for
+                  constraining the values within and among
+                  entities.</doc:description>
+                  <doc:example>(year &gt; 1900 and year &lt;
+                  1990)</doc:example>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="language" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Language</doc:tooltip>
+                <doc:summary>The language that the is used to express or
+                implement the check constraint.</doc:summary>
+                <doc:description>The language element declares the language
+                that is used to implement the check constraint.  This is
+                typically the name and version of a programming language such as
+                Java, C, Perl, Basic, or other.  Sometime it is the name and
+                version of a scriptable analysis system such as SAS, Matlab, R,
+                or SPlus.
+                </doc:description>
+                <doc:example>Perl 5.6.1</doc:example>
+                
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="foreignKey">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Foreign Key</doc:tooltip>
+            <doc:summary>A foreign key relationship among entities</doc:summary>
+            <doc:description>The foreignKey element defines a foreign key
+            relationship among entities which relates this entity to another's
+            primary key.
+            </doc:description>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:group ref="ForeignKeyGroup"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="joinCondition">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Join Condition</doc:tooltip>
+            <doc:summary>A non primary/foreign key join</doc:summary>
+            <doc:description>The joinCondition element describes any join of two
+            tables that is not done with a primary/foreign key
+            relationship.</doc:description>
+            <doc:example>JOIN code</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ForeignKeyGroup"/>
+            <xs:element name="referencedKey">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Key</doc:tooltip>
+                  <doc:summary>The set of attributes to which a foreign key
+                  constraint refers.</doc:summary>
+                  <doc:description>The referencedKey element defines set of
+                  attributes to which a foreign key constraint refers. If the
+                  key refers to the primary key in the referenced entity, then
+                  the "referencedKey" is optional.  For a foreign key, the set
+                  of attributes must match an identifying key in the referenced
+                  entity.</doc:description>
+                  <doc:example>site, plot</doc:example>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="attributeReference" type="res:NonEmptyStringType" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Attribute Reference</doc:tooltip>
+                        <doc:summary>The identifier of an attribute found
+                        in the identified entity</doc:summary>
+                        <doc:description>The attributeReference element is the
+                        identifier of an attribute that can be found in the
+                        identified entity. This id will be unique within an
+                        entity and specifies that the attribute participates
+                        in the key that is being defined.</doc:description>
+                        <doc:example>site</doc:example>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="notNullConstraint">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Not Null Constraint</doc:tooltip>
+            <doc:summary>A constraint that indicates that no null values
+            should be present for an attribute.</doc:summary>
+            <doc:description>The notNullConstraint element defines a constraint
+            that indicates that no null values should be present for an
+            attribute in this entity.</doc:description>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="ConstraintBaseGroup"/>
+            <xs:element name="key">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Key</doc:tooltip>
+                  <doc:summary>The set of attributes to which this constraint
+                  applies.</doc:summary>
+                  <doc:description>The key element defines the set of attributes
+                  to which this constraint applies. For a primary key or a
+                  unique key, the set of attributes must be identifying. For a
+                  foreign key, the set of attributes must match an identifying
+                  key in the referenced entity. For a 'not null' constraint, the
+                  key indicates the attribute which should not be
+                  null.</doc:description>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="attributeReference" type="res:NonEmptyStringType" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Attribute Reference</doc:tooltip>
+                        <doc:summary>The identifier of an attribute found
+                        in the identified entity</doc:summary>
+                        <doc:description>The attributeReference element is the
+                        identifier of an attribute that can be found in the
+                        identified entity. This id will be unique within an
+                        entity and specifies that the attribute participates
+                        in the key that is being defined.</doc:description>
+                        <doc:example>site</doc:example>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:simpleType name="CardinalityChildOccurancesType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Child portion of a cardinality expression</doc:tooltip>
+        <doc:summary>Child portion of a cardinality expression Allowed values
+        are positive integers including zero or the string value
+        "many".</doc:summary>
+        <doc:description>The CardinalityChildOccurancesType element defines the
+        child portion of a cardinality expression.  Allowed values are positive
+        integers including zero or the string value "many".</doc:description>
+        <doc:example>0,1, 2, 15,many</doc:example>
+        
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:union memberTypes="xs:integer">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="many"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:group name="ConstraintBaseGroup">
+    <xs:sequence>
+      <xs:element name="constraintName" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Name of the constraint</doc:tooltip>
+            <doc:summary>A meaningfull name of the constraint.</doc:summary>
+            <doc:description>The constraintName element is a name which
+            represents a human readable and meaningful name for the
+            constraint.</doc:description>
+            <doc:example>PrimaryKey_birdSurvey</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="constraintDescription" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Description of the constraint</doc:tooltip>
+            <doc:summary>Descibes the purpose of the constraint.</doc:summary>
+            <doc:description>The constraintDescription element describes the
+            nature of the constraint. It might be a description of a check
+            condition, or a statement about the composition of a primary key or
+            the nature of the relationship between two database tables or two
+            ascii files.</doc:description>
+            <doc:example>1.Must be greater than 0 but less than 100 2. "The
+            primary key of the table BIRD_SURVEY is composed of two
+            attributes:speciesCode and observationDate 3. The species name
+            associated with the species code in survey.txt can be found in the
+            file speciesList.txt</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ForeignKeyGroup">
+    <xs:sequence>
+      <xs:group ref="ConstraintBaseGroup"/>
+      <xs:element name="key">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Key</doc:tooltip>
+            <doc:summary>The set of attributes to which this constraint
+            applies.</doc:summary>
+            <doc:description>The key element defines the set of attributes to
+            which this constraint applies. For a primary key or a unique key,
+            the set of attributes must be identifying. For a foreign key, the
+            set of attributes must match an identifying key in the referenced
+            entity. For a 'not null' constraint, the key indicates the attribute
+            which should not be null.</doc:description>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="attributeReference" type="res:NonEmptyStringType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Attribute Reference</doc:tooltip>
+                  <doc:summary>The identifier of an attribute found
+                  in the identified entity</doc:summary>
+                  <doc:description>The attributeReference element is the
+                  identifier of an attribute that can be found in the
+                  identified entity. This id will be unique within an
+                  entity and specifies that the attribute participates
+                  in the key that is being defined.</doc:description>
+                  <doc:example>site</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="entityReference" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Referenced Entity ID</doc:tooltip>
+            <doc:summary>The id of the parent-entity in a foreign key
+            constraint.</doc:summary>
+            <doc:description>The entityReference element contains the id of the
+            entity to which a foreign key refers, otherwise known as the
+            parent-entity or parent-table. This should be an identifier that
+            matches one of the "identifier" elements for an
+            entity.</doc:description>
+            <doc:example>knb.79.4</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="relationshipType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Relationship type: Identifying or
+            non-identifying</doc:tooltip>
+            <doc:summary>Relationship type: Identifying or
+            non-identifying</doc:summary>
+            <doc:description>The relationshipType element defines identifying
+            relationships that propagate from the parent entity's primary key to
+            the child's primary key. Non-identifying relationships propagate the
+            parent's primary key as a non-key attribute of the child
+            entity.</doc:description>
+            <doc:example>relationshipType code</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="identifying"/>
+            <xs:enumeration value="non-identifying"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="cardinality" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Cardinality of the relationship between two
+            entities.</doc:tooltip>
+            <doc:summary>Cardinality of the relationship between a parent
+            entity and a child entity.</doc:summary>
+            <doc:description>The cardinality element represents a statement of
+            the relationship between parent and child entities. Cardinality is
+            expressed as the ratio of related parent and child
+            entities. Cardinality 1 to N is a specific form of cardinality in
+            which zero or one parent records are related to a specified number
+            of child records. The cardinality ratio for the parent entity
+            depends on whether the "existence" is mandatory (one or more) or
+            optional (zero to ...).</doc:description>
+            <doc:example>One to many</doc:example>
+            <doc:example>One to 10</doc:example>
+            <doc:example>Zero or One to Many</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parentOccurences">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Parent portion of a 1 to exactly N
+                  cardinality</doc:tooltip>
+                  <doc:summary>Parent portion of a 1 to exactly N cardinality.
+                  May have a value of either 0 or 1.</doc:summary>
+                  <doc:description>The parentOccurences element describes the
+                  Parent portion of a 1 to exactly N cardinality. May have a
+                  value of either 0 or 1. Value of 0 implies that the
+                  "existence" of a child record is optional.  Value of 1 implies
+                  that the "existence" of a child record is
+                  mandatory.</doc:description>
+                  <doc:example>One to 10, Zero or One to Many</doc:example>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:integer">
+                  <xs:enumeration value="0"/>
+                  <xs:enumeration value="1"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+            <xs:element name="childOccurences" type="CardinalityChildOccurancesType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Child portion of the cardinality
+                  expression</doc:tooltip>
+                  <doc:summary>Child portion of a cardinality expression
+                  Allowed values are positive integers including zero or the
+                  string value "many".</doc:summary>
+                  <doc:description>The childOccurences element describes the
+                  child portion of a cardinality expression Allowed values are
+                  positive integers including zero or the string value
+                  "many"</doc:description>
+                  <doc:example>2, 15, many</doc:example>
+                  
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-coverage.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-coverage.xsd
@@ -1,0 +1,1324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cit="eml://ecoinformatics.org/literature-2.1.1" xmlns:rp="eml://ecoinformatics.org/party-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns="eml://ecoinformatics.org/coverage-2.1.1" xmlns:unit="eml://ecoinformatics.org/units-2.1.1" targetNamespace="eml://ecoinformatics.org/coverage-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/literature-2.1.1" schemaLocation="eml-literature.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/party-2.1.1" schemaLocation="eml-party.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/units-2.1.1" schemaLocation="eml-unitTypeDefinitions.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+               '$RCSfile: eml-coverage.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.95 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-coverage</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+            The eml-coverage module - Geographic, temporal, and taxonomic extents
+            of resources
+          </title>
+            <para>
+            The eml-coverage module contains fields for describing the coverage
+            of a resource in terms of time, space, and taxonomy. These
+            coverages (temporal, spatial, and taxonomic) represent the extent
+            of applicability of the resource in those domains.
+            The Geographic coverage section allows for 2 means of expressing
+            coverage
+            on the surface of the earth: 1) via a set of bounding coordinates
+            that define the North, South, East and West points in a rectangular
+            area, optionally including a bounding altitude,
+            and 2) using a G-Ring polygon definition, where an irregularly
+            shaped area may be defined using a ordered list of
+            latitude/longitude coordinates.  A G-Ring may also include an
+            "inner G-Ring" that defines one or more
+            "cut-outs" in the area, i.e. the donut hole concept.
+          </para>
+            <para>
+            The temporal coverage section allows for the definition of either a
+            single date or time, or a range of dates or times. These may be
+            expressed as a calendar date according to the ISO 8601 Date and Time
+            Specification, or by using an alternate time scale, such as the
+            geologic time scale. Currently, EML does not have specific fields to indicate
+            that a data resource may be "ongoing." Two examples are data tables 
+			that are planned to be appended in the future, or resources 
+            with complex connection definitions (such as to a database) which may return 
+			data in real time. It is important that EML be 
+            able to  handle data from both the "producer" and "consumer" points of view,
+            although currently the temporal coverage modules are designed for the latter.
+            There is no universally acceptable recommendation for describing "ongoing" data
+            within EML. Some groups have chosen to use the &lt;alternateTimeScale&gt; 
+            node for the end date, with a value of "ongoing," although this practice
+            is not endorsed by the EML authors. A better solution could be to use very
+			general content for the endDate (such as only the current year) so that the 
+			data are accurately described, and searches return datasets as expected.
+			A future version of EML will 
+            accommodate such data types with coverage elements specific to their needs.
+          </para>
+            <para>
+            The taxonomic coverage section allows for detailed description of
+            the taxonomic extent of the dataset or resource.  The taxonomic
+            classification consists of a recursive set of taxon rank names,
+            their values, and their common names.  This construct allows for a
+            taxonomic hierarchy to be built to show the level of identification
+            (e.g. Rank Name = Kingdom, Rank Value = Animalia, Common Name =
+            Animals, and so on down the hierarchy.) The taxonomic coverage
+            module also allows for the definition of the classification system
+            in cases where alternative systems are used.
+          </para>
+            <para>
+            The eml-coverage module, like other modules, may be
+            "referenced" via the &lt;references&gt; tag.  This allows
+            the coverage extent to be described once, and then used as a
+            reference in other locations within the EML document via its ID.
+          </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all datasets where spatial, temporal or taxonomic
+        coverage is important</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:complexType name="Coverage">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Coverage</doc:tooltip>
+        <doc:summary>
+          Spatial, temporal, and taxonomic coverage information.
+        </doc:summary>
+        <doc:description>This field is a container for the spatial, temporal
+        and taxonomic coverages that apply to various resources, often dataset
+        resources.  Please see the individual descriptions of the sub fields for
+        more detail.
+        </doc:description>
+        <doc:example>Please see the individual sub fields for specific
+        examples.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="geographicCoverage" type="GeographicCoverage">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Geographic coverage</doc:tooltip>
+              <doc:summary>Geographic coverage information.</doc:summary>
+              <doc:description>Geographic Coverage is a container for spatial
+              information about a project, a resource, or an entity within a
+              resource. It allows a bounding box for the overall coverage (in
+              lat long), and also allows description of arbitrary polygons with
+              exclusions.</doc:description>
+              <doc:example>Please see the individual sub fields for specific
+              examples.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="temporalCoverage">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Temporal coverage</doc:tooltip>
+              <doc:summary>Temporal coverage information.</doc:summary>
+              <doc:description>This field specifies temporal coverage, and
+              allows coverages to be a single point in time, multiple points in
+              time, or a range of dates. Dates can be expressed in terms of both
+              calendar dates and geologic dating systems.</doc:description>
+              <doc:example>Please see the individual sub fields for specific
+              examples.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="TemporalCoverage">
+                <xs:attribute name="system" type="res:SystemType" use="optional"/>
+                <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="taxonomicCoverage">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Taxonomic coverage</doc:tooltip>
+              <doc:summary>Taxonomic coverage information.</doc:summary>
+              <doc:description>Taxonomic Coverage is a container for Taxonomic
+              information about a project, a resource, or an entity within a
+              resource. It includes a list of species names (or higher level
+              ranks) from one or more classification systems.</doc:description>
+              <doc:example>Please see the individual sub fields for specific
+              examples.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="TaxonomicCoverage">
+                <xs:attribute name="system" type="res:SystemType" use="optional"/>
+                <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="TemporalCoverage">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Temporal coverage</doc:tooltip>
+        <doc:summary>Temporal coverage information.</doc:summary>
+        <doc:description>The temporal coverage fields are intended to be used
+        in describing the date and time of an event. It allows for three
+        general descriptions: a single date or time, multiple dates or times, and a
+        range of date or times.</doc:description>
+        <doc:example>Please see the individual sub fields for specific
+        examples.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:choice>
+        <xs:element name="singleDateTime" type="SingleDateTimeType" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Single Date/Time</doc:tooltip>
+              <doc:summary>Means of encoding a single date and
+              time</doc:summary>
+              <doc:description>The singleDateTime field is intended to
+              describe a
+              single date and time for an event. There is a choice between two
+              options: a calendar date with a time, or a geologic
+              age.</doc:description>
+              <doc:example>Please see the individual sub-elements for
+              example.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="rangeOfDates">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Range of dates/times</doc:tooltip>
+              <doc:summary>Means of encoding a range of dates and
+        times.</doc:summary>
+              <doc:description>The 'RangeOfDatesType' field is intended to be used for
+        describing a range of dates and/or times. It may be used multiple times
+        to document multiple date ranges. It allows for two 'singleDateTime'
+        fields, the first to be used as the beginning dateTime, and the second
+        to be used as the ending dateTime of the range.</doc:description>
+              <doc:example>Please see the examples from the 'singleDateTime'
+        field for specific examples.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="beginDate" type="SingleDateTimeType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Begin Date</doc:tooltip>
+                    <doc:summary>A single time stamp signifying the beginning of
+              some time period</doc:summary>
+                    <doc:description>A single time stamp signifying the beginning of
+              some time period.  There is a choice between two
+              options: a calendar date with a time, or a geologic
+              age.</doc:description>
+                    <doc:example>Please see the individual sub-elements for
+              example.</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="endDate" type="SingleDateTimeType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>End Date</doc:tooltip>
+                    <doc:summary>A single time stamp signifying the end of
+              some time period</doc:summary>
+                    <doc:description>A single time stamp signifying the end of
+              some time period.  There is a choice between two
+              options: a calendar date with a time, or a geologic
+              age.</doc:description>
+                    <doc:example>Please see the individual sub-elements for
+              example.</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="SingleDateTimeType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Single Date/Time</doc:tooltip>
+        <doc:summary>Means of encoding a single date and time</doc:summary>
+        <doc:description>The SingleDateTimeType field is intended to describe a
+        single date and time for an event. There is a choice between two
+        options: a calendar date with a time, or a geologic
+        age.</doc:description>
+        <doc:example>Please see the individual sub-elements for
+        example.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="calendarDate" type="res:yearDate">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Calendar date</doc:tooltip>
+              <doc:summary>The calendar date for an event.</doc:summary>
+              <doc:description>The calendar date field is used to express a
+              date, giving the year, month, and day. The format should be one
+              that complies with the International Standards Organization's
+              standard 8601. The recommended format for EML is YYYY-MM-DD,
+              where Y is the four digit year, M is the two digit month code
+              (01 - 12, where January = 01), and D is the two digit day of
+              the month (01 - 31). This field can also be used to enter just 
+	      the year portion of a date.</doc:description>
+              <doc:example>2001-01-01</doc:example>
+              <doc:example>2001-10-12</doc:example>
+              <doc:example>2001</doc:example>
+              <doc:example>1895</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="time" type="xs:time" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Time of day</doc:tooltip>
+              <doc:summary>The time of day for an event.</doc:summary>
+              <doc:description>The time field is used to express the hour
+              (and optionally minute, or minute and second) of the day for an
+              event, and should comply with the International Standards
+              Organization's standard 8601. The recommended format for EML is
+              hh:mm:ssTZD, where hh is the two digit hour of the day, mm is
+              the two digit minute of the hour, and ss is the two digit
+              second of the minute. TZD stands for Time Zone Designator which
+              is used to handle time zone offsets. Times may be expressed in
+              two ways: 1) UTC (Coordinated Universal Time, also known as
+              Greenwich Mean Time, or GMT), with a special UTC designator
+              ("Z"), 2) local time, together with a time zone offset in hours
+              and minutes. A time zone offset of "+hh:mm" indicates that the
+              date or time uses a local time zone which is "hh" hours and "mm"
+              minutes ahead of UTC. A time zone offset of "-hh:mm" indicates
+              a local time zone which is "hh" hours
+              and "mm" minutes behind UTC.</doc:description>
+              <doc:example>1) 08:31:22Z , which means eight thirty one and 22
+              seconds in the morning at Coordinated Universal Time (Greenwich
+              Mean Time). 2) 14:06:09-08:00 , which means six minutes, nine
+              seconds past two o'clock p.m., Pacific Standard Time (which is
+              offset eight hours behind UTC)</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:element name="alternativeTimeScale">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Alternative Time Scale</doc:tooltip>
+            <doc:summary>A name, code, or date describing an event or period
+            in an alternative time scale, such as one of the geologic time
+            scales.</doc:summary>
+            <doc:description>A name, code, or date describing an event or
+            period in an alternative time scale, for instance as an absolute
+            date calculated using a named dating method, or as a relative
+            date that is drawn from stratigraphy or biostratigraphy.
+            Calendar dates as provided in the ISO
+            8601 dating system used in the standard CSDGM are not adequate to
+            describe geologic time periods. Absolute geologic time is usually
+            measured in millions of years before present, but may use different
+            units and relative base times. Relative geologic time is measured by
+            subdivisions of the earth's geology. in an order based upon relative
+            age, most commonly, vertical or stratigraphic position. The actual
+            dating systems used in geologic studies often tie relative times
+            measured through stratigraphy or biostratigraphy to a particular
+            absolute time using radioisotope dating techniques, among others. As
+            these methods for absolute dating have improved, the estimates of
+            the dates for strata have changed, consequently, it would be
+            inaccurate to record absolute dates in situations where relative
+            dates were measured.  This structure is provided as an optional
+            alternative to the standard calendar dates provided by ISO 8601.
+            </doc:description>
+            <doc:example>Please see the individual sub-fields for specific
+            examples.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="timeScaleName" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>alternative time scale</doc:tooltip>
+                  <doc:summary>Name of a recognized alternative time
+                  scale.</doc:summary>
+                  <doc:description>Name of a recognized alternative time scale.
+                  This includes 'Absolute' as the name of the time scale for
+                  measuring geologic dates before the present and names of
+                  geologic dating systems that are arrangements of symbols or
+                  names in order of relative geologic time.</doc:description>
+                  <doc:example>'Absolute', 'Geomagnetic Polarity Time Scale',
+                  'International Geological Time Scale',
+                  'Oxygen-Isotope'</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="timeScaleAgeEstimate" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Time scale age estimate</doc:tooltip>
+                  <doc:summary/>
+                  <doc:description>Either an absolute date or a relative age
+                  name describing an event or period in an alternative time
+                  scale such as the Geologic Time Scale.</doc:description>
+                  <doc:example>For example, '300 Ma' (300 million years before
+                  present) is a Geologic_Age_Estimate based on the Absolute
+                  Geologic_Time_Scale, 'C28r' is a chron name from the
+                  Geomagnetic Polarity Time Scale, and 'Maastrichtian' and
+                  'Jurassic' are names from the International Geological Time
+                  Scale. Since different relative geologic time scales are
+                  often not aligned, multiple geologic dates may need to be
+                  specified. For example, the Geomagnetic Polarity Time Scale
+                  chron 'C29r', at the K/T boundary lies in both the
+                  'Maastrichtian' and the 'Danian' stages from the
+                  International Geological Time Scale, thus if you were
+                  documenting this event using the International Geological
+                  Time Scale, both 'Maastrichtian' and 'Danian' should be
+                  included here.</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="timeScaleAgeUncertainty" type="res:NonEmptyStringType" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Time scale age uncertainty</doc:tooltip>
+                  <doc:summary>The error estimate for the alternative time
+                  scale.</doc:summary>
+                  <doc:description>The error estimate for the alternative time.
+                  This should include the units of measure, a description of
+                  what the error estimate represents and how it was
+                  calculated.</doc:description>
+                  <doc:example>+/- 5 Ma (Million Years)</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="timeScaleAgeExplanation" type="res:NonEmptyStringType" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Time scale age explanation</doc:tooltip>
+                  <doc:summary>The name and/or description of the method used to
+                  calculate the time scale age estimate.</doc:summary>
+                  <doc:description>The name and/or description of the method
+                  used to calculate the age estimate. Detailed information
+                  about the method may be provided through references
+                  contained in the Time Scale Citation field.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="timeScaleCitation" type="cit:CitationType" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Time Scale citation</doc:tooltip>
+                  <doc:summary>Citation for works providing detailed information
+                  about any element of the time scale age.</doc:summary>
+                  <doc:description>Citation for works providing detailed
+                  information about any element of the time scale
+                  age.</doc:description>
+                  <doc:example>For example, a publication describing the
+                  methodology used for carbon dating or describing the basic
+                  geologic time scale in more detail could be cited
+                  here.</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+  <xs:complexType name="GeographicCoverage">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Geographic coverage</doc:tooltip>
+        <doc:summary>Geographic coverage information.</doc:summary>
+        <doc:description>Geographic Coverage is a container for spatial
+        information about a a project, a resource, or an entity within a
+        resource. It is meant for general information and not for accurate
+mapping.  More specific information, including mapping projections, is covered by EML in
+the spatialReference schema.</doc:description>
+        <doc:example>Please see the individual sub-elements for specific
+        examples.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="geographicDescription" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Description of geographic extent</doc:tooltip>
+              <doc:summary>Short text description of the geographic areal domain of
+              the data set.</doc:summary>
+              <doc:description>
+                <section xmlns="">
+                  <para>geographicDescription is a short text description of a dataset's 
+              geographic areal domain. A text description is especially important to 
+              provide a geographic                           setting 
+               when the extent of the data set cannot be well described
+              by the "boundingCoordinates", or in the case of data
+              which are not specifically geospatial. Assuming the
+              "boundingCoordinates" do not adequately describe the
+              extent of the data set, the discrepancy can be identified and
+              described here. The coordinates may define a rectangle around a
+              country, with this geographicDescription element
+              containing a disclaimer  
+               and/or further details concerning the border.
+             A study of the diseases of salmon may not have a
+              specific geographic extent associated with it, but the salmon
+               were collected in the states of Washington and Oregon.
+              The "boundingCoordinates" might form a
+              general rectangle around the states of Washington and Oregon, but
+              the "geographicDescription" might describe the fact
+              that the study took place only along
+              certain rivers within those states. </para>
+                  <para>
+              This data element differs
+              from the standard data element "Place_Keyword" in that it allows
+              a free text description of the geographic extent, rather than
+              just a list of words or phrases useful as an index of location
+              names associated with the data set.  </para>
+                  <para>This element can also contain information
+              about the collection of the boundingCoordinates, e.g., an altitude value that is referenced
+              to Mean Lower Low Water, or the projection system that the latitude and 
+              longitude coordinates were taken from.</para>
+                </section>
+              </doc:description>
+              <doc:example>"Manistee River watershed"</doc:example>
+              <doc:example>
+              "extent of 7 1/2 minute quads containing any property belonging
+              to Yellowstone National Park"</doc:example>
+              <doc:example> "ponds and reservoirs larger
+              than 2 acres in Jefferson County, Colorado". </doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="boundingCoordinates">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Bounding coordinates</doc:tooltip>
+              <doc:summary>The four margins (N, S, E, W) of a bounding box on the earth's surface, 
+              or when considered in lat-lon pairs, the corners of the box. To define a single
+              point, use the same value in each lat or lon pair.  These elements are meant to convey general 
+              information and are not for accurate mapping.  More specific information may be
+              included by using the elements in the spatialReference schema.</doc:summary>
+              <doc:description>
+                <section>
+                  <para>Bounding Coordinates are the four margins (N, S, E, W) of a bounding box, 
+              or when considered in lat-lon pairs, the corners of the box. These elements are meant to convey general 
+              information and are not for accurate mapping.  More specific information may be
+              included by using the elements in the spatialReference schema.</para>
+                  <para>The limits of coverage of a data set should be expressed
+              as decimal latitudes and longitudes, and in the order western-most,
+              eastern-most, northern-most, and southern-most. By convention, 
+              latitudes and longitudes are referenced to the  Equator and to the Prime Meridian
+              (the datums), respectively. 
+              By definition, the 0 and 180 meridians themselves do not belong in either hemisphere, 
+              but local conventions may place them in either. All coordinates are typed as decimals. 
+              Since all four elements are required, a bounding area that is a 
+              single point should use the same values for
+              northBoundingCoordinate and southBoundingCoordinate, and likewise
+             for westBoundingCoordinate and eastBoundingCoordinate. </para>
+                  <para>In the case of a data set that comprises 
+                    all longitudes (e.g., a horizontal band between 2 parallels that fully 
+                    encompasses the earth ), please use a westBoundingCoordinate of -180.0, and an
+                    eastBoundingCoordinate of 180.0 (or +180.0). In this case, it could be considered geographically                
+                    appropriate to specify both values as "180" (or any other meridian), but this could 
+                    also be interpreted as only the  meridian itself, so this is not recommended</para>
+                </section>
+              </doc:description>
+              <doc:example>Please see the individual sub-fields.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="westBoundingCoordinate">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>West bounding coordinate, in decimal degrees</doc:tooltip>
+                    <doc:summary>Western-most limit of a bounding box, expressed in degrees of
+                    longitude.</doc:summary>
+                    <doc:description>The westBoundingCoordinate field defines
+                    the longitude of the western-most point of the bounding box that is being
+                    described. A longitude coordinate is typed as a decimal, i.e.,
+                    decimal degrees from -180 to 180, inclusive. Decimal degrees may be expressed to 
+                    any precision desired. Fractions of a degree in minutes and seconds should be 
+                    converted to degree fractions. Strings denoting direction or hemisphere (e.g., 'W' or 'west') are 
+                    not allowed. Longitudes east of the prime meridian must be specified by
+                    a plus sign (+), or by the absence of a minus sign (-), and longitudes west of 
+                    the meridian shall be  prefixed with minus sign (-). In the case of a data set that comprises 
+                    all longitudes (e.g., a horizontal band between 2 parallels that fully 
+                    encompasses the earth ), please use a westBoundingCoordinate of -180.0, and an
+                    eastBoundingCoordinate of 180.0 (or +180.0). In this case, it could be considered geographically                
+                    appropriate to specify both values as "180" (or any other meridian), but this could 
+                    also be interpreted as only the  meridian itself, so this is not recommended.</doc:description>
+                    <doc:example>-118.25</doc:example>
+                    <doc:example>+25</doc:example>
+                    <doc:example>45.24755</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:decimal">
+                    <xs:minInclusive value="-180.0"/>
+                    <xs:maxInclusive value="180.0"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="eastBoundingCoordinate">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>East bounding coordinate</doc:tooltip>
+                    <doc:summary>Eastern-most limit of a bounding box, expressed in degrees of
+                    longitude.</doc:summary>
+                    <doc:description>The eastBoundingCoordinate field defines
+                    the longitude of the eastern-most point of the bounding box that is being
+                    described. A longitude coordinate is typed as a decimal, i.e.,
+                    decimal degrees from -180 to 180, inclusive. Decimal degrees may be expressed to 
+                    any precision desired. Fractions of a degree in minutes and seconds should be 
+                    converted to degree fractions. Strings denoting direction or hemisphere (e.g., 'W' or 'west') are 
+                    not allowed. Longitudes east of the prime meridian must be specified by
+                    a plus sign (+), or by the absence of a minus sign (-), and longitudes west of 
+                    the meridian shall be  prefixed with minus sign (-). In the case of a data set that comprises 
+                    all longitudes (e.g., a horizontal band between 2 parallels that fully 
+                    encompasses the earth ), please use a westBoundingCoordinate of -180.0, and an
+                    eastBoundingCoordinate of 180.0 (or +180.0). In this case, it could be considered geographically                
+                    appropriate to specify both values as "180" (or any other meridian), but this could 
+                    also be interpreted as only the  meridian itself, so this is not recommended.</doc:description>
+                    <doc:example>-118.25</doc:example>
+                    <doc:example>+25</doc:example>
+                    <doc:example>45.24755</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:decimal">
+                    <xs:minInclusive value="-180.0"/>
+                    <xs:maxInclusive value="180.0"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="northBoundingCoordinate">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>North bounding coordinate</doc:tooltip>
+                    <doc:summary>Northern-most lilmit of a bounding box expressed in latitude.</doc:summary>
+                    <doc:description>The northBoundingCoordinate field defines
+                    the latitude of the northern-most point of the bounding box that is being
+                    described. A latitude coordinate is typed as a decimal, i.e.,
+                    decimal degrees from -180 to 180, inclusive. Decimal degrees may be expressed to 
+                    any precision desired. Fractions of a degree in minutes and seconds should be 
+                    converted to degree fractions. Strings denoting direction or hemisphere (e.g., 'N' or north') are 
+                    not allowed. Latitudes north of the equator must be denoted by
+                    a plus sign (+), or by the absence of a minus sign (-), and latitudes south of 
+                    the equator shall be  prefixed with minus sign (-).  A location with latitude of +90 (90)
+                     or -90 degrees will specify the position at the North or South Pole,
+                    respectively.</doc:description>
+                    <doc:example>-18.25</doc:example>
+                    <doc:example>+25</doc:example>
+                    <doc:example>65.24755</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:decimal">
+                    <xs:minInclusive value="-90.0"/>
+                    <xs:maxInclusive value="90.0"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="southBoundingCoordinate">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>South bounding coordinate</doc:tooltip>
+                    <doc:summary>Southern-most limit of the bounding box expressed in latitude.</doc:summary>
+                    <doc:description>The southBoundingCoordinate field defines
+                    the latitude of the southern-most point of the bounding box that is being
+                    described. A latitude coordinate is typed as a decimal, i.e.,
+                    decimal degrees from -180 to 180, inclusive. Decimal degrees may be expressed to 
+                    any precision desired. Fractions of a degree in minutes and seconds should be 
+                    converted to degree fractions. Strings denoting direction or hemisphere (e.g., 'N' or north') are 
+                    not allowed. Latitudes north of the equator must be denoted by
+                    a plus sign (+), or by the absence of a minus sign (-), and latitudes south of 
+                    the equator shall be  prefixed with minus sign (-).  A location with latitude of +90 (90)
+                     or -90 degrees will specify the position at the North or South Pole,
+                    respectively.</doc:description>
+                    <doc:example>-118.25</doc:example>
+                    <doc:example>+25</doc:example>
+                    <doc:example>84.24755</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:decimal">
+                    <xs:minInclusive value="-90.0"/>
+                    <xs:maxInclusive value="90.0"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="boundingAltitudes" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Bounding altitudes</doc:tooltip>
+                    <doc:summary>The vertical limits of a data set expressed
+                    by altitude.</doc:summary>
+                    <doc:description>The bounding altitude field is intended to
+                    contain altitudinal (elevation) measurements for
+                    the bounding box being described. It allows for minimum and
+                    maximum altitude fields, as well as a field for the units
+                    of measure. The combination of these fields provide the
+                    vertical extent information for the bounding box. </doc:description>
+                    <doc:example>Please see the individual sub-fields for
+                    specific examples.</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="altitudeMinimum" type="xs:decimal">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Minimum altitude</doc:tooltip>
+                          <doc:summary>The minimum altitude extent of
+                          coverage.</doc:summary>
+                          <doc:description>The minimum altitude extent of
+                          coverage for the bounding box that is being
+                          described. The minimum altitude should be in
+                          reference to a known datum (e.g., Mean Sea Level), which should be part of the geographicDescription.</doc:description>
+                          <doc:example>100.6 </doc:example>
+                          <doc:example>-12 </doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="altitudeMaximum" type="xs:decimal">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Maximum altitude</doc:tooltip>
+                          <doc:summary>The maximum altitude extent of
+                          coverage.</doc:summary>
+                          <doc:description>The maximum altitude extent of
+                          coverage for the bounding box that is being
+                          described. The maximum altitude should be in
+                          reference to a known datum, which should be part of the geographicDescription.</doc:description>
+                          <doc:example>100.6</doc:example>
+                          <doc:example>-10</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="altitudeUnits" type="unit:LengthUnitType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Altitude Units</doc:tooltip>
+                          <doc:summary>The unit of altitude </doc:summary>
+                          <doc:description>The unit that the altitude is expressed in. See the description under the Type definition</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="datasetGPolygon" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Polygon data set</doc:tooltip>
+              <doc:summary>This construct creates a spatial ring with a
+              hollow center.</doc:summary>
+              <doc:description>This construct creates a spatial ring with a
+              hollow center.  This doughnut shape is specified by the outer
+              ring (datasetGPolygonOuterRing) and the inner exclusion zone
+              (datasetGPolygonExclusionGRing) which can be thought of as the
+              hole in the center of a doughnut.  This is useful for defining
+              areas such as the shores of a pond where you only want to specify
+              the shore excluding the pond itself.</doc:description>
+              <doc:example>Please see the individual sub-fields for specific
+              examples.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="datasetGPolygonOuterGRing">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Outer polygon</doc:tooltip>
+                    <doc:summary>
+                      The outer containment loop of a datasetGPolygon.
+                    </doc:summary>
+                    <doc:description>
+                      <section xmlns="">
+                        <para>The outer containment loop of a
+                    datasetGPolygon.  This is the outer part of the doughnut
+                    shape that encompasses the broadest area of coverage. 
+                    It can be created either by a gRing (list of points) or 3 or more gRingPoints. 
+                    See the sub-elements and their Type definitions for more specific 
+                    information.</para>
+                        <para>
+                    This element is generally analogous to the FGDC outer ring although
+                    somewhat differently specified.  Documentation for an FGDC G-Ring 
+                    states that 4 points are required 
+                    to define a polygon, and the first and last should be identical. 
+                    However this is not enforceable in XML Schema, and so in EML
+                    a minimum of 3 &lt;gRingPoint&gt;s is required to define a polygon, and
+                    it can be assumed that a polygon is closed by joining the last point to the
+                    first.
+                    XSL stylesheets that transform EML instances to the FGDC specification 
+                    should repeat the first gRingPoint node as the last when creating a list of points.
+                    </para>
+                      </section>
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:choice>
+                    <xs:sequence>
+                      <xs:element name="gRingPoint" type="GRingPointType" minOccurs="3" maxOccurs="unbounded">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>G Ring Point</doc:tooltip>
+                            <doc:summary>A single geographic location</doc:summary>
+                            <doc:description>A single geographic location.  As a child of &lt;datasetGPolygonOuterGRing&gt;
+                            a minimum of 3 are required to define a polygon. The polygon is presumed to be closed. Please see the sub elements and the Type description for more information about creating a point location.</doc:description>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:element>
+                    </xs:sequence>
+                    <xs:element name="gRing" type="GRingType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>G-Ring</doc:tooltip>
+                          <doc:description>A set of ordered pairs of floating-point numbers,
+        The number of points in the string is not enforced by EML. 
+        However, authors should note that in order for this field is to be directly translated to FGDC, 4 points should
+        be included in the string. See the Type for more information on constructing the string. </doc:description>
+                          <!--  <doc:example> 12.453,15.0 5,101 -111,45</doc:example> -->
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="datasetGPolygonExclusionGRing" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Exclusion polygon</doc:tooltip>
+                    <doc:summary>
+                    Data Set G-Polygon Exclusion G-Ring, the
+                    closed nonintersecting boundary of a void area (or hole in
+                    an interior area).
+                    </doc:summary>
+                    <doc:description>
+                      <section xmlns="">
+                        <para> the
+                    closed nonintersecting boundary of a void area (or hole in
+                    an interior area).  This is the center of the doughnut
+                    shape created by the datasetGPolygon. It can be created either by
+                    a gRing (list of points) or one or more gRingPoints. See the sub-elements and their 
+                    Type definitions for more information.</para>
+                        <para>
+                        This element is generally analogous to an FGDC exclusion ring "Data Set G-Polygon 
+                        Exclusion G-Ring", although it's children are
+                    somewhat differently described.  Documentation for the FGDC component states that
+                    4 points are required to define a polygon, and the first and last should be identical. 
+                    However this EML element requires only one point so that a single point can be
+                    excluded,  presumably, a single station.  If multiple single stations are to be 
+                    excluded, then authors should include multiple &lt;datasetGPolygonExclusionGRing&gt;s.
+                                                </para>
+                      </section>
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:choice>
+                    <xs:element name="gRingPoint" type="GRingPointType" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>G Ring Point</doc:tooltip>
+                          <doc:summary>A single geographic location</doc:summary>
+                          <doc:description>A single geographic location.  This is useful if you
+        register your datasets by a single geospatial point, such as the
+        lat/long of your research station. Please see the sub elements and the Type description 
+		for more information on constructing a gRingPoint</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="gRing" type="GRingType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>G-Ring</doc:tooltip>
+                          <doc:description>A set of ordered pairs of floating-point numbers,
+        See the Type for more information</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="GRingPointType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>G-Ring point</doc:tooltip>
+        <doc:summary>
+        A single geographic location.
+        </doc:summary>
+        <doc:description>A single geographic location.  This is useful if you
+        register your datasets by a single geospatial point, such as the
+        lat/long of your research station.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="gRingLatitude">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>G-Ring Latitude</doc:tooltip>
+            <doc:summary>
+            The latitude of a point of the
+            g-ring.</doc:summary>
+            <doc:description> A latitude coordinate is typed as a decimal, i.e.,
+                    decimal degrees from -90 to 90, inclusive. Decimal degrees may be expressed to 
+                    any precision desired. Fractions of a degree in minutes and seconds should be 
+                    converted to degree fractions. Strings denoting direction or hemisphere (e.g., 'S' or 'south') are 
+                    not allowed. Latitudes north of the equator must be specified by
+                    a plus sign (+), or by the absence of a minus sign (-), and latitudes south of 
+                    the equator shall be  prefixed with minus sign (-). </doc:description>
+            <doc:example>34.123</doc:example>
+            <doc:example>-18.25</doc:example>
+            <doc:example>+78.25</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="-90.0"/>
+            <xs:maxInclusive value="90.0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="gRingLongitude">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>G-Ring Longitude</doc:tooltip>
+            <doc:summary/>
+            <doc:description>The longitude of a point of the
+            g-ring A longitude coordinate is typed as a decimal, i.e.,
+                    decimal degrees from -180 to 180, inclusive. Decimal degrees may be expressed to 
+                    any precision desired. Fractions of a degree in minutes and seconds should be 
+                    converted to degree fractions. Strings denoting direction or hemisphere (e.g., 'W' or 'west') are 
+                    not allowed. Longitudes east of the prime meridian must be specified by
+                    a plus sign (+), or by the absence of a minus sign (-), and longitudes west of 
+                    the meridian shall be  prefixed with minus sign (-).</doc:description>
+            <doc:example>-118.25</doc:example>
+            <doc:example>+25</doc:example>
+            <doc:example>45.24755</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="-180.0"/>
+            <xs:maxInclusive value="180.0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="GRingType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>G-Ring</doc:tooltip>
+        <doc:summary/>
+        <doc:description>
+          <section xmlns="">
+            <para>A set of ordered pairs of floating-point numbers,
+        separated by commas, in which the first number in each pair is the
+        longitude of a point and the second is the latitude of the point.
+        Longitude and latitude are specified in decimal degrees with north
+        latitudes positive and south negative, east longitude positive and west
+        negative</para>
+            <para>Note on the relationship to FGDC:
+        This element is generally analogous to the FGDC component for ring, 
+        although implemented somewhat differently. Documentation for FGDC
+        states that 4 points are required to define a polygon, and the first and last 
+        should be identical, although this is not enforceable in XML Schema. In addition,
+        EML does not enforce any pattern on the string used for a GRingType, so that
+        it may be used differently as a child of EML's &lt;datasetGPolygonOuterGRing&gt;  
+        or &lt;datasetGPolygonExclusionGRing&gt; elements.
+        If authors of EML instance documents wish the contents of this element  to be 
+        directly translated to FGDC, they should comply with the example below when
+        constructing their strings. Alternatively, in most cases, a sequence of gRingPoints 
+        can be used in EML instances, which can be processed into content for an 
+        FGDC Data Set G-Polygon G-Ring.</para>
+          </section>
+        </doc:description>
+        <doc:example>This is an acceptable gRing:
+</doc:example>
+        <doc:example>
+        12, 2.0987
+        12, -7.5555
+        34.345,10.40
+        </doc:example>
+        <doc:example>However, for translation to FGDC, construct your string like this:</doc:example>
+        <doc:example>
+        -119.453,35.0
+        -125,37.5555
+        -122,40
+        -119.453,35.0
+        </doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="TaxonomicCoverage">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Taxonomic coverage</doc:tooltip>
+        <doc:summary>Taxonomic coverage information.</doc:summary>
+        <doc:description>Taxonomic Coverage is a container for taxonomic
+        information about a project, a resource, or an entity within a
+        resource.</doc:description>
+        <doc:example>Please see the individual sub-fields for specific
+        examples.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="taxonomicSystem" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Taxonomic system</doc:tooltip>
+              <doc:summary>Documentation of taxonomic sources, procedures, and
+              treatments.</doc:summary>
+              <doc:description>Documentation of taxonomic sources, procedures,
+              and treatments.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="classificationSystem" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Classification system/authority</doc:tooltip>
+                    <doc:summary>Information about the classification system or
+                    authority used.</doc:summary>
+                    <doc:description>Information about the classification
+                    system or authority used.</doc:description>
+                    <doc:example>Flora of North America</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="classificationSystemCitation" type="cit:CitationType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Taxonomic citation</doc:tooltip>
+                          <doc:summary/>
+                          <doc:description>Relevant literature for documenting
+                          the used classification system.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="classificationSystemModifications" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Classification system
+                          modification</doc:tooltip>
+                          <doc:summary/>
+                          <doc:description>A description of any modifications
+                          or exceptions made to the classification system or
+                          authority used.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="identificationReference" type="cit:CitationType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Non-authoritative citation</doc:tooltip>
+                    <doc:summary/>
+                    <doc:description>Information on any non-authoritative
+                    materials (e.g. field guides) useful for reconstructing the
+                    actual identification process.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="identifierName" type="rp:ResponsibleParty" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Identifier's Name</doc:tooltip>
+                    <doc:summary/>
+                    <doc:description>Information about the individual(s)
+                    responsible for the identification(s) of the specimens or
+                    sightings, etc.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="taxonomicProcedures" type="res:NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Taxonomic procedures</doc:tooltip>
+                    <doc:summary/>
+                    <doc:description>Description of the methods used for the
+                    taxonomic identification.</doc:description>
+                    <doc:example>specimen processing, comparison with museum
+                    materials, keys and key characters, chemical or genetic
+                    analyses</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="taxonomicCompleteness" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Taxonomic completeness</doc:tooltip>
+                    <doc:summary/>
+                    <doc:description>Information concerning the proportions and
+                    treatment of unidentified materials, estimates of the
+                    importance and possible identities of uncertain
+                    determinations, synonyms or other incorrect usages, taxa
+                    not well treated or requiring further work, and expertise
+                    of field workers.</doc:description>
+                    <doc:example>materials sent to experts, and not yet
+                    determined</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="vouchers" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Specimen information</doc:tooltip>
+                    <doc:summary/>
+                    <doc:description>Information on the types of specimen, the
+                    repository, and the individuals who identified the
+                    vouchers.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="specimen" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Specimen type</doc:tooltip>
+                          <doc:summary/>
+                          <doc:description>A word or phrase describing the type
+                          of specimen collected.</doc:description>
+                          <doc:example>herbarium specimens, blood samples,
+                          photographs, individuals, or batches</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="repository">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Storage location of
+                          specimen</doc:tooltip>
+                          <doc:summary/>
+                          <doc:description>Information about the curator or
+                          contact person and/or agency responsible for the
+                          specimens.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="originator" type="rp:ResponsibleParty" maxOccurs="unbounded">
+                            <xs:annotation>
+                              <xs:appinfo>
+                                <doc:tooltip>Originator</doc:tooltip>
+                                <doc:summary>A person or organization asociated
+                                with this resource.</doc:summary>
+                                <doc:description>The 'originator' element
+                                provides the full name of the person,
+                                organization, or position associated with the
+                                resource. Typically, the originator role is set
+                                to "owner" to indicate the list of parties who
+                                "own" the resource, but other roles such as
+                                "principal investigator", "author", and
+                                "editor" are provided.</doc:description>
+                                <doc:example>Please see the examples within the
+                                sub fields for the responsible
+                                party.</doc:example>
+                              </xs:appinfo>
+                            </xs:annotation>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="generalTaxonomicCoverage" type="res:NonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>General taxonomic coverage</doc:tooltip>
+              <doc:summary>A description of the range of taxa addressed in the
+              data set or collection.</doc:summary>
+              <doc:description>A description of the range of taxa addressed in
+              the data set or collection.</doc:description>
+              <doc:example>"All vascular plants were identified to family or
+              species, mosses and lichens were identified as moss or
+              lichen."</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="taxonomicClassification" type="TaxonomicClassificationType" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Taxonomic classification</doc:tooltip>
+              <doc:summary>Information about the range of taxa addressed in the data
+        set or collection.</doc:summary>
+              <doc:description>Information about the range of taxa addressed in the
+        data set or collection. See the Type definition for more information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="TaxonomicClassificationType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Taxonomic classification</doc:tooltip>
+        <doc:summary>Information about the range of taxa addressed in the data
+        set or collection.</doc:summary>
+        <doc:description>Information about the range of taxa addressed in the
+        data set or collection. It is recommended that one provide information
+        starting from the taxonomic rank of kingdom, to a level which reflects
+        the data set or collection being documented. The levels of Kingdom,
+        Division/Phylum, Class, Order, Family, Genus, and Species should be
+        included as ranks as appropriate. Because the taxonomic ranks are
+        hierarchical, the Taxonomic Classification field is self-referencing to
+        allow for an arbitrary depth of rank, down to
+        species.</doc:description>
+        <doc:example>The Taxonomic Classification field consists of a sequence
+        of 4 fields: taxonomic rank, taxonomic rank value, common name, and
+        finally Taxonomic Classification (self-referencing). Please see the
+        sub-fields for specific examples.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="taxonRankName" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Taxon rank name</doc:tooltip>
+            <doc:summary>The name of the taxonomic rank for which the Taxon
+            rank value is provided.</doc:summary>
+            <doc:description>The name of the taxonomic rank for which the
+            Taxon rank value is provided. This field allows for the name one
+            of the accepted levels of Taxa.</doc:description>
+            <doc:example>'Kingdom', 'Division/Phylum', 'Class', 'Order',
+            'Family', 'Genus', and 'Species'</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="taxonRankValue" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Taxon rank value</doc:tooltip>
+            <doc:summary>The name representing the taxonomic rank of the
+            taxon being described.</doc:summary>
+            <doc:description>The name representing the taxonomic rank of the
+            taxon being described. The values included may be referenced from
+            an authoritative source such as the Integrated Taxonomic
+            Information System (ITIS)in the U.S. (http://www/itis.usda.gov)
+            and in Canada (http://sis.agr.gc.ca/pls/itisca/taxaget). Also,
+            Species2000 is another source of taxonomic information, found at
+            (http://www.sp2000.org)</doc:description>
+            <doc:example>'Acer' would be an example of a genus rank value, and
+            'Acer rubrum' would be an example of a species rank value with the 
+            common name of red maple. It is recommended to
+            start with Kingdom and include ranks down to the most detailed
+            level possible.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="commonName" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Common name</doc:tooltip>
+            <doc:summary>Specification of applicable common
+            names.</doc:summary>
+            <doc:description>Specification of applicable common names. These
+            common names may be general descriptions of a group of organisms
+            if appropriate.</doc:description>
+            <doc:example>insects, vertebrate, grasses, waterfowl, vascular
+            plants, red maple.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="taxonomicClassification" type="TaxonomicClassificationType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Taxonomic classification</doc:tooltip>
+            <doc:summary>Information about the range of taxa addressed in the data
+        set or collection.</doc:summary>
+            <doc:description>Information about the range of taxa addressed in the
+        data set or collection. See the Type definition for more information.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <!--
+<xs:element name="taxonomicClassification" type="TaxonomicClassificationType" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Taxonomic classification</doc:tooltip>
+              <doc:summary>Information about the range of taxa addressed in the data
+        set or collection.</doc:summary>
+              <doc:description>Information about the range of taxa addressed in the
+        data set or collection. See the Type definition for more information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+
+-->
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-dataTable.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-dataTable.xsd
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+    xmlns:ent="eml://ecoinformatics.org/entity-2.1.1" 
+    xmlns:att="eml://ecoinformatics.org/attribute-2.1.1" 
+    xmlns:con="eml://ecoinformatics.org/constraint-2.1.1" 
+    xmlns="eml://ecoinformatics.org/dataTable-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/dataTable-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+  schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/entity-2.1.1" 
+  schemaLocation="eml-entity.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/attribute-2.1.1" 
+  schemaLocation="eml-attribute.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/constraint-2.1.1" 
+  schemaLocation="eml-constraint.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-dataTable.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.47 $'
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA    
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-dataTable</doc:moduleName>
+        <doc:moduleDescription>
+        <section xmlns="">
+          <title>
+            The eml-dataTable module - Logical information
+            about data table entities
+          </title>
+          <para>
+            The eml-dataTable module is used to describe the logical
+            characteristics of each tabular set of information in a dataset. A
+            series of comma-separated text files may be considered a dataset,
+            and each file would subsequently be considered a dataTable entity
+            within the dataset.  Since the eml-dataTable module extends the
+            eml-entity module, it uses all of the common entity elements to
+            describe the table, along with a few elements specific to just data
+            table entities.  The eml-dataTable module allows for the
+            description of each attribute (column/field/variable) within the
+            data table through the use of the eml-attribute module.  Likewise,
+            there are fields used to describe the physical distribution of the
+            data table, its overall coverage, the methodology used in creating
+            the data, and other logical structure information such as its
+            orientation, case sensitivity, etc.
+          </para>
+        </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>The EML dataTable Module is used to document
+        datasets with one or more data tables.</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="dataTable" type="DataTableType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Table Entity descriptor</doc:tooltip>
+        <doc:summary>Descriptor of one table entity in the
+        dataset.</doc:summary>
+        <doc:description>The dataTable element is a descriptor of one entity in
+        the dataset identified by its name. This element can contain
+        information about the dataTable's orientation, number of records, case
+        sensitivity, and temporal, geographic and taxonomic coverage. Because
+        the dataTable element refers to the complex type 'DataTableType', it
+        must contain all the elements defined for the type. 
+        description for DataTableType to review component element
+        rules.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="DataTableType">
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="ent:EntityGroup"/>
+        <xs:element name="attributeList" type="att:AttributeListType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute List</doc:tooltip>
+              <doc:summary>The list of attributes associated with this
+              entity.</doc:summary>
+              <doc:description>The list of attributes associated with this
+              entity.  For more information see the eml-attribute
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="constraint" type="con:ConstraintType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Constraint</doc:tooltip>
+              <doc:summary/>
+              <doc:description>Description of any relational constraints on '
+              this entity.  For more information see the eml-constraint
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="caseSensitive" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Case sensitivity</doc:tooltip>
+              <doc:summary>Specification of text case sensitivity in the
+              dataTable.</doc:summary>
+              <doc:description>The caseSensitive element
+              specifies text case sensitivity of the data in the
+              dataTable. The valid values are yes or no. If it is set to
+              yes, then values of attributes that differ only in case (e.g.,
+              LOW, low) represent distinct values.  If set to no, then values 
+              of attributes that differ only in case represent the same value.
+              </doc:description>
+              <doc:example>yes</doc:example>
+              <doc:example>no</doc:example>
+              
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="yes"/>
+              <xs:enumeration value="no"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="numberOfRecords" type="res:NonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Number of records</doc:tooltip>
+              <doc:summary>The integer count of the number of records in the
+              dataTable.</doc:summary>
+              <doc:description>The numberOfRecords element contains a count
+              of the number of records in the dataTable. This is typically an
+              integer value, and only includes records that represent
+              observations. It would not include any details of physical
+              formatting such as the number of header lines (see eml-physical
+              for that information).</doc:description>
+              <doc:example>975</doc:example>
+              
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-documentation.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-documentation.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns="eml://ecoinformatics.org/documentation-2.1.1" 
+    xmlns:txt="eml://ecoinformatics.org/text-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/documentation-2.1.1"
+    elementFormDefault="unqualified">
+  <xs:import namespace="eml://ecoinformatics.org/text-2.1.1" 
+  schemaLocation="eml-text.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-documentation.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2008-08-27 21:30:04 $'
+      '$Revision: 1.27 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+  </xs:annotation>
+  <xs:element name="moduleDocs">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="moduleName" type="xs:string" form="qualified"/>
+        <xs:element name="moduleDescription" type="txt:TextType" form="qualified"/>
+        <xs:element name="recommendedUsage" type="xs:string" form="qualified"/>
+        <xs:element name="standAlone" type="xs:string" form="qualified"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tooltip" type="xs:string"/>
+  <xs:element name="summary" type="xs:string"/>
+  <xs:element name="description" type="txt:TextType"/>
+  <xs:element name="example" type="txt:TextType"/>
+  <xs:element name="lineage" type="xs:string"/>
+  <xs:element name="module" type="xs:string"/>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-entity.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-entity.xsd
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:con="eml://ecoinformatics.org/constraint-2.1.1" xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" xmlns:phys="eml://ecoinformatics.org/physical-2.1.1" xmlns:md="eml://ecoinformatics.org/methods-2.1.1" xmlns:att="eml://ecoinformatics.org/attribute-2.1.1" xmlns:txt="eml://ecoinformatics.org/text-2.1.1" xmlns="eml://ecoinformatics.org/entity-2.1.1" targetNamespace="eml://ecoinformatics.org/entity-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/physical-2.1.1" schemaLocation="eml-physical.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/methods-2.1.1" schemaLocation="eml-methods.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/attribute-2.1.1" schemaLocation="eml-attribute.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/constraint-2.1.1" schemaLocation="eml-constraint.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/text-2.1.1" schemaLocation="eml-text.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-entity.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.89 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-entity</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-entity module - Entity level information within datasets
+            </title>
+            <para>
+              The eml-entity module defines the logical characteristics of
+              each entity in the dataset. Entities are usually tables of
+              data (eml-dataTable). Data tables may be ascii text files,
+              relational database tables, spreadsheets or other type of
+              tabular data with a fixed logical structure. Related to data
+              tables are views (eml-view) and stored
+              procedures (eml-storedProcedure). Views and stored procedures
+              are produced by an RDBMS or related system. Other types of data
+              such as: raster (eml-spatialRaster), vector (eml-spatialVector) or
+              spatialReference image data are also data entities. An
+              otherEntity element would be used to describe types of entities
+              that are not described by any other entity type.
+            </para>
+            <para>
+              The eml-entity module, like other modules, may be
+              "referenced" via the &lt;references&gt; tag.  This
+              allows an entity document to be described once, and then
+              used as a reference in other locations within the EML document
+              via its ID.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>This module is used to describe data
+        entities.</doc:recommendedUsage>
+        <doc:standAlone>Only when 'otherEntity' is used.</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="otherEntity" type="OtherEntityType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Other Entity</doc:tooltip>
+        <doc:summary>Descriptor of single data entity in a dataset of a type
+        not specifically described in eml.</doc:summary>
+        <doc:description>The other entity element is a descriptor of a
+        not-otherwise-defined entity in the dataset, identified by its name.
+        The element can contain information about the entity's basic identity,
+        its temporal, geographic and taxonomic coverage, and its
+        type.</doc:description>
+        <doc:example>Photograph of rocky intertidal plot 12 from Santa Cruz
+        Island</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="OtherEntityType">
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="EntityGroup"/>
+        <xs:sequence>
+          <xs:element name="attributeList" type="att:AttributeListType" minOccurs="0">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Attribute List</doc:tooltip>
+                <doc:summary>The list of attributes associated with this
+                entity.</doc:summary>
+                <doc:description>The list of attributes associated with this
+                entity.  For more information see the eml-attribute
+                module.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="constraint" type="con:ConstraintType" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Constraint</doc:tooltip>
+                <doc:summary/>
+                <doc:description>Description of any relational constraints on '
+                this entity.  For more information see the eml-constraint
+                module.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="entityType" type="res:NonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Entity type</doc:tooltip>
+                <doc:summary>Contains the name of the type for this
+                entity.</doc:summary>
+                <doc:description>The entityType field contains the name of the
+                entity's type. The entity's type is typically the name of the
+                type of data represented in the entity, such as "photograph".
+                This field is used only if this is an 'other' entity and you
+                want to specify the kind of "other" entity this
+                is.</doc:description>
+                <doc:example>Photograph</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:group name="EntityGroup">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Base Entity descriptors</doc:tooltip>
+        <doc:summary>Basic information about an entity common to all entity
+        types.</doc:summary>
+        <doc:description>The EntityGroup defines the common structure for
+        descriptions of any type of entity, including the name and attributes
+        of the entity. The term entity is used in the sense of an entity in a
+        relational model. The most common entity is a table, something with
+        columns and rows, but can also represent an image or other type of
+        data. See 'eml-attribute' for descriptions of the required attribute
+        fields.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alternateIdentifier" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Alternate Identifier</doc:tooltip>
+            <doc:summary>A secondary identifier for this entity</doc:summary>
+            <doc:description>An additional, secondary identifier for this
+            entity. The primary identifier belongs in the "id" attribute, but
+            additional identifiers that are used to label this entity, possibly
+            from different data management systems, can be listed
+            here.</doc:description>
+            <doc:example>VCR3465</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="system" type="res:SystemType" use="optional">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Identifier System</doc:tooltip>
+                    <doc:summary>The system in which this id is
+                    relevant</doc:summary>
+                    <doc:description>The information management system within
+                    which this identifier has relevance. Generally, the
+                    identifier would be unique within the "system" and would be
+                    sufficient to retrieve the entity from the system. The
+                    system is often a URL or URI that identifies the main entry
+                    point for the information management
+                    system.</doc:description>
+                    <doc:example>
+                    http://knb.ecoinformatics.org/knb/</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="entityName" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Entity name</doc:tooltip>
+            <doc:summary>The name of the entity name</doc:summary>
+            <doc:description>The name identifies the entity in the dataset:
+            file name, name of database table, etc.</doc:description>
+            <doc:example>SpeciesAbundance1996</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="entityDescription" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Entity description</doc:tooltip>
+            <doc:summary>General description of the entity and its
+            contents</doc:summary>
+            <doc:description>Text generally describing the entity, its type,
+            and relevant information about the data in the
+            entity.</doc:description>
+            <doc:example>Species abundance data for 1996 at the VCR LTER
+            site</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="physical" type="phys:PhysicalType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>physical descriptors</doc:tooltip>
+            <doc:summary>Description of the physical format of the entity
+            </doc:summary>
+            <doc:description>Information on the physical format of this entity.
+            Each logical entity can be serialized in one or more physical
+            formats, which can be described here.  For each physical format,
+            provide a "physical" element that describes the format and how
+            to obtain that version.  Two physical elements MUST describe
+            the same entity precisely (i.e., after obtaining and parsing
+            the physical data stream described under each physical element,
+            one MUST end with an identical logical entity).
+            For more information see the eml-physical module.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="coverage" type="cov:Coverage" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>coverage descriptors</doc:tooltip>
+            <doc:summary>Information on the geographic, spatial and temporal
+            coverages used in this entity.</doc:summary>
+            <doc:description>Information on the geographic, spatial and temporal
+            coverages used in this entity.  Please see the eml-coverage module
+            for more information.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="methods" type="md:MethodsType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>method descriptions</doc:tooltip>
+            <doc:summary/>
+            <doc:description>Information on the specific methods used to collect
+            information in this entity.  Please see the eml-methods module for
+            more information.</doc:description>
+            <doc:example/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="additionalInfo" type="txt:TextType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Additional Information</doc:tooltip>
+            <doc:summary>Any extra information pertitent to the
+            entity.</doc:summary>
+            <doc:description>This field provides any information that is not
+            characterized by the other entity metadata
+            fields.</doc:description>
+            <doc:example>Multiple sampling events represented</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-literature.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-literature.xsd
@@ -1,0 +1,1223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:rp="eml://ecoinformatics.org/party-2.1.1" xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:acc="eml://ecoinformatics.org/access-2.1.1" xmlns:proj="eml://ecoinformatics.org/project-2.1.1" xmlns="eml://ecoinformatics.org/literature-2.1.1" targetNamespace="eml://ecoinformatics.org/literature-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/party-2.1.1" schemaLocation="eml-party.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/access-2.1.1" schemaLocation="eml-access.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/project-2.1.1" schemaLocation="eml-project.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+      '$RCSfile: eml-literature.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.61 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-literature</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-literature module - Citation specific
+              information
+            </title>
+            <para>
+              The eml-literature module contains information that describes
+              literature resources. It is intended to provide overview
+              information about the literature citation, including title,
+              abstract, keywords, and contacts. Citation types follow the
+              conventions laid out by
+              <ulink url="http://www.endnote.com">EndNote</ulink>,
+              and there is an attempt to
+              represent a compatible subset of the EndNote citation types.
+              These citation types include: article, book, chapter, edited
+              book, manuscript, report, thesis, conference proceedings,
+              personal communication, map, generic, audio visual, and
+              presentation.  The "generic" citation type would be
+              used when one of the other types will not work.
+            </para>
+            <para>
+              The eml-literature module, like other modules, may be
+              "referenced" via the &lt;references&gt; tag.  This
+              allows a citation to be described once, and then used as a
+              reference in other locations within the EML document via its ID.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>All datasets with literary
+        citations</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="citation" type="CitationType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Literature Citation</doc:tooltip>
+        <doc:summary>Information describing a literature
+        resource.</doc:summary>
+        <doc:description>The citation element contains general information
+        about a literature resource that is being documented, or a piece of
+        literature that is being cited in support of a given resource, such as
+        a dataset. It contains sub-elements that are specific to a literature
+        resource such as a book, a journal article, a thesis, etc. It extends
+        the generic resource elements with literature specific
+        fields.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="CitationType">
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="res:ResourceGroup"/>
+        <xs:element name="contact" type="rp:ResponsibleParty" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Contact</doc:tooltip>
+              <doc:summary>An optional contact individual for this citation</doc:summary>
+              <doc:description>The contact field contains information about an alternate person to be contacted 
+              about this citation. Usually, the first author serves as the contact for a citation resource, e.g., a reprint request. In some cases, an alternate individual(s) may serve that function, and can be indicated here. Since contact is of the type rp:ResponsibleParty, a reference may be used.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:choice>
+          <xs:element name="article" type="Article">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>article</doc:tooltip>
+                <doc:summary>Information for full citation of a journal article
+                or other periodical article.</doc:summary>
+                <doc:description>The article field provides sub-fields for a
+                full citation of an article in a journal or other
+                periodical.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="book" type="Book">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Book</doc:tooltip>
+                <doc:summary>Information for full citation of a
+                book</doc:summary>
+                <doc:description>The book field provides sub-fields for a full
+                citation of a book.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="chapter" type="Chapter">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Book Chapter</doc:tooltip>
+                <doc:summary>Information for citation of a chapter in a
+                book</doc:summary>
+                <doc:description>The book chapter allows citation of a single
+                chapter or section of a book. The "creator" for a book chapter
+                are the chapter's authors, while the "editor" is the book
+                editors. Likewise, "title" is the chapter title, while
+                "bookTitle" is the title of the whole book.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="editedBook" type="Book">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Book</doc:tooltip>
+                <doc:summary>Information for full citation of an edited
+                book</doc:summary>
+                <doc:description>The edited book represents a book which was
+                edited by one or more editors, but whose chapters were possibly
+                authored by others. The editors of an edited book should be
+                listed in the "creator" field.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="manuscript" type="Manuscript">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>unpublished manuscipt</doc:tooltip>
+                <doc:summary>Information about an unpublished
+                manuscript</doc:summary>
+                <doc:description>The manuscript field provides sub-fields for a
+                full citation of an unpublished manuscript.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="report" type="Report">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Report</doc:tooltip>
+                <doc:summary>Information about a report published by an
+                institution.</doc:summary>
+                <doc:description>The report may be self published by the
+                institution or through a publisher. They usually are available
+                by request to the institution or can be purchased from the
+                publisher.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="thesis" type="Thesis">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Thesis as part of a degree</doc:tooltip>
+                <doc:summary>Information about a thesis that has been written
+                as part of a degree requirement and is frequently published in
+                small numbers by the degree awarding institution.</doc:summary>
+                <doc:description>Information about a thesis that has been
+                written as part of a degree requirement and is frequently
+                published in small numbers by the degree awarding
+                institution.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="conferenceProceedings" type="ConferenceProceedings">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>conference proceedings</doc:tooltip>
+                <doc:summary>The published notes, papers, presentations etc...
+                of a conference.</doc:summary>
+                <doc:description>The published notes, papers, presentations,
+                etc..., of a conference.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="personalCommunication" type="PersonalCommunication">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Personal communication</doc:tooltip>
+                <doc:summary>A personal communication that has been saved
+                online or as hard-copy.</doc:summary>
+                <doc:description>This could be a widely distributed memo, an
+                e-mail, a transcript from a conversation or interview,
+                etc...</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="map" type="Map">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>map</doc:tooltip>
+                <doc:summary>This element describes the map that is being cited
+                or cataloged.</doc:summary>
+                <doc:description>This element describes the map that is being
+                cited or cataloged, including its geographic coverage and
+                scale.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="generic" type="Generic">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Generic Citation</doc:tooltip>
+                <doc:summary>This reference type was created for references
+                that do not fit in to the other existing reference
+                types</doc:summary>
+                <doc:description>This reference type was created for references
+                that do not fit in to the other existing reference
+                types.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="audioVisual" type="AudioVisual">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>audio visual</doc:tooltip>
+                <doc:summary>This reference type is meant to cover all forms of
+                audio and visual media.</doc:summary>
+                <doc:description>This reference type is meant to cover all
+                forms of audio and visual media, including film, video,
+                broadcast, other electronic media.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="presentation" type="Presentation">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Unpublished Presentation</doc:tooltip>
+                <doc:summary>An unpublished presentation from a conference,
+                workshop, workgroup, symposium etc.</doc:summary>
+                <doc:description>An unpublished presentation from a conference,
+                workshop, workgroup, symposium, etc. It will be provided upon
+                request in either in paper and/or electronic form. If the
+                presentation was actually published in a proceedings, use the
+                conferenceProceedings type instead.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="Article">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>article</doc:tooltip>
+        <doc:summary>Information for full citation of a journal article or
+        other periodical article.</doc:summary>
+        <doc:description>The article field provides sub-fields for a full
+        citation of an article in a journal or other
+        periodical.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="journal" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Journal Name</doc:tooltip>
+            <doc:summary>The name of the journal, magazine, newspaper, zine,
+            etc... in which the article was published.</doc:summary>
+            <doc:description>The name of the journal, magazine, newspaper,
+            zine, etc... in which the article was published.</doc:description>
+            <doc:example>"Ecology"</doc:example>
+            <doc:example>"New York Times"</doc:example>
+            <doc:example>"Harper's"</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="volume" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Journal Volume</doc:tooltip>
+            <doc:summary>The volume of the journal in which the article
+            appears</doc:summary>
+            <doc:description>The volume field is used to describe the volume of
+            the journal in which the article appears.</doc:description>
+            <doc:example>"Volume I"</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="issue" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Journal issue</doc:tooltip>
+            <doc:summary>The issue of the journal in which the article
+            appears</doc:summary>
+            <doc:description>The issue field is used to describe the issue of
+            the journal in which the article appears.</doc:description>
+            <doc:example>November 2001</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="pageRange" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Journal Pages</doc:tooltip>
+            <doc:summary>The beginning and end page numbers of the journal
+            article</doc:summary>
+            <doc:description>The page range field is used for the beginning and
+            ending pages of the journal article that is being
+            documented.</doc:description>
+            <doc:example>115-122</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publisher" type="rp:ResponsibleParty" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization that actually publishes the
+            article</doc:summary>
+            <doc:description>The organization that physically puts together the
+            article and publishes it.</doc:description>
+            <doc:example>Harper Collins</doc:example>
+            <doc:example>University Of California Press</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationPlace" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication Place</doc:tooltip>
+            <doc:summary>The location at which the work was
+            published.</doc:summary>
+            <doc:description>The location at which the work was published. This
+            is usually the name of the city in which the publishing house
+            produced the work.</doc:description>
+            <doc:example>New York</doc:example>
+            <doc:example>London</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ISSN" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>International Standard Serial Number</doc:tooltip>
+            <doc:summary>The unique Internation Standard Serial
+            Number</doc:summary>
+            <doc:description>The ISSN, or International Standard Serial Number
+            that has been assigned to this literature
+            resource.</doc:description>
+            <doc:example>ISSN 1234-5679</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Book">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Book</doc:tooltip>
+        <doc:summary>Information for full citation of a book</doc:summary>
+        <doc:description>The book field provides sub-fields for a full citation
+        of a book.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="publisher" type="rp:ResponsibleParty">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization that actually publishes the
+            book</doc:summary>
+            <doc:description>The organization that physically puts together the
+            book and publishes it.</doc:description>
+            <doc:example>Harper Collins</doc:example>
+            <doc:example>University Of California Press</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationPlace" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication Place</doc:tooltip>
+            <doc:summary>The location at which the work was
+            published.</doc:summary>
+            <doc:description>The location at which the work was published. This
+            is usually the name of the city in which the publishing house
+            produced the work.</doc:description>
+            <doc:example>New York</doc:example>
+            <doc:example>London</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="edition" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Book edition</doc:tooltip>
+            <doc:summary>The edition of the book being described.</doc:summary>
+            <doc:description>The edition field is to document the edition of
+            the book that is being described.</doc:description>
+            <doc:example>Second Edition</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="volume" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Book volume</doc:tooltip>
+            <doc:summary>The volume of the book that is part of a
+            series.</doc:summary>
+            <doc:description>The volume field is used to describe the volume
+            number of a book that is part of a multi-volume series of
+            books.</doc:description>
+            <doc:example>Volume 2</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="numberOfVolumes" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Number of Volumes</doc:tooltip>
+            <doc:summary>Number of volumes in a collection</doc:summary>
+            <doc:description>Number of volumes in a
+            collection</doc:description>
+            <doc:example>12</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalPages" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Total book pages</doc:tooltip>
+            <doc:summary>The total number of pages in the book.</doc:summary>
+            <doc:description>The total pages field is used to describe the
+            total number of pages in the book that is being
+            described.</doc:description>
+            <doc:example>628</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalFigures" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Number of figures in book</doc:tooltip>
+            <doc:summary>The total number of figures in the book.</doc:summary>
+            <doc:description>the total figures field is used to describe the
+            total number of figures, diagrams, and plates in the book that is
+            being documented.</doc:description>
+            <doc:example>45</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalTables" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Number of tables in book</doc:tooltip>
+            <doc:summary>The total number of tables in a book.</doc:summary>
+            <doc:description>The total tables field is used to describe the
+            total number of tables that are present in the book that is being
+            documented.</doc:description>
+            <doc:example>10</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ISBN" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>International Standard Book Number</doc:tooltip>
+            <doc:summary>The unique Internation Standard Book
+            Number</doc:summary>
+            <doc:description>The ISBN, or International Standard Book Number
+            that has been assigned to this literature
+            resource.</doc:description>
+            <doc:example>ISBN 1-861003-11-0</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Chapter">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Book Chapter</doc:tooltip>
+        <doc:summary>Information for citation of a chapter in a
+        book</doc:summary>
+        <doc:description>The book chapter allows citation of a single chapter
+        or section of a book. The "creator" for a book chapter are the
+        chapter's authors, while the "editor" is the book editors. Likewise,
+        "title" is the chapter title, while "bookTitle" is the title of the
+        whole book.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="Book">
+        <xs:sequence>
+          <xs:element name="chapterNumber" type="res:NonEmptyStringType" minOccurs="0">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Chapter number</doc:tooltip>
+                <doc:summary>The chapter number of interest within a
+                book</doc:summary>
+                <doc:description>The chapter number of the chapter of a book
+                that is being described.</doc:description>
+                <doc:example>7</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="editor" type="rp:ResponsibleParty" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Book editor</doc:tooltip>
+                <doc:summary>The name of the editor of the book.</doc:summary>
+                <doc:description>The book editor field is used to document the
+                name of the editor of the book that is being described. The
+                editor may be a person, organization, or a role within an
+                organization.</doc:description>
+                <doc:example>Tom Christiansen</doc:example>
+                <doc:example>Institute of Marine Science</doc:example>
+                <doc:example>Publication Manager</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="bookTitle" type="res:NonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Book title</doc:tooltip>
+                <doc:summary>The title of the book.</doc:summary>
+                <doc:description>The book title field is used to document the
+                title of the book that is being described.</doc:description>
+                <doc:example>War and Peace</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="pageRange" type="res:NonEmptyStringType" minOccurs="0">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Chapter page range</doc:tooltip>
+                <doc:summary>The beginning and ending page numbers of a
+                chapter.</doc:summary>
+                <doc:description>The page range field is used to document the
+                beginning and ending pages of a chapter in a
+                book.</doc:description>
+                <doc:example>25-122</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ConferenceProceedings">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>conference proceedings</doc:tooltip>
+        <doc:summary>The published notes, papers, presentations etc... of a
+        conference.</doc:summary>
+        <doc:description>The published notes, papers, presentations, etc..., of
+        a conference.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="Chapter">
+        <xs:sequence>
+          <xs:element name="conferenceName" type="res:NonEmptyStringType" minOccurs="0">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Conference Name</doc:tooltip>
+                <doc:summary>The name of the conference whose proceedings have
+                been published.</doc:summary>
+                <doc:description>The name of the conference whose proceedings
+                have been published.</doc:description>
+                <doc:example>North American Science Symposium</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="conferenceDate" type="res:NonEmptyStringType" minOccurs="0">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Conference Date</doc:tooltip>
+                <doc:summary>The date the conference was held.</doc:summary>
+                <doc:description>The date the conference was
+                held.</doc:description>
+                <doc:example>November 1-6, 1998</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="conferenceLocation" type="rp:Address" minOccurs="0">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Conference Location</doc:tooltip>
+                <doc:summary>The location where the conference was
+                held.</doc:summary>
+                <doc:description>The location where the conference was
+                held.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Manuscript">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>unpublished manuscipt</doc:tooltip>
+        <doc:summary>Information about an unpublished manuscript</doc:summary>
+        <doc:description>The manuscript field provides sub-fields for a full
+        citation of an unpublished manuscript.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="institution" type="rp:ResponsibleParty" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Manuscript publication information</doc:tooltip>
+            <doc:summary>The address and contact information needed to request
+            a manuscript.</doc:summary>
+            <doc:description>The institution information field is used to
+            provide contact and address information that would be needed to
+            request an unpublished manuscript</doc:description>
+            <doc:example>Please see the individual sub-fields for specific
+            examples.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalPages" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Total manuscript pages</doc:tooltip>
+            <doc:summary>The total number of pages in the
+            manuscript.</doc:summary>
+            <doc:description>The total pages field is used to describe the
+            total number of pages in the manuscript that is being
+            described.</doc:description>
+            <doc:example>628</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Report">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Report</doc:tooltip>
+        <doc:summary>Information about a report published by an
+        institution.</doc:summary>
+        <doc:description>The report may be self published by the institution or
+        through a publisher. They usually are available by request to the
+        institution or can be purchased from the publisher.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="reportNumber" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Report Number</doc:tooltip>
+            <doc:summary>The unique identification number assigned to the
+            report.</doc:summary>
+            <doc:description>The report number field is used to describe the
+            unique identification number that has been issued by the report
+            institution for the report being described.</doc:description>
+            <doc:example>22</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publisher" type="rp:ResponsibleParty" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization that actually publishes the
+            report</doc:summary>
+            <doc:description>The organization that physically put together the
+            report and publishes it.</doc:description>
+            <doc:example>Harper Collins</doc:example>
+            <doc:example>University Of California Press</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationPlace" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication Place</doc:tooltip>
+            <doc:summary>The location at which the work was
+            published.</doc:summary>
+            <doc:description>The location at which the work was published. This
+            is usually the name of the city in which the publishing house
+            produced the work.</doc:description>
+            <doc:example>New York</doc:example>
+            <doc:example>London</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalPages" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Total report pages</doc:tooltip>
+            <doc:summary>The total number of pages in the report.</doc:summary>
+            <doc:description>The total pages field is used to describe the
+            total number of pages in the report that is being
+            described.</doc:description>
+            <doc:example>628</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PersonalCommunication">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Personal communication</doc:tooltip>
+        <doc:summary>A personal communication that has been saved online or as
+        hard-copy.</doc:summary>
+        <doc:description>This could be a widely distributed memo, an e-mail, a
+        transcript from a conversation or interview, etc...</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="publisher" type="rp:ResponsibleParty" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization that actually publishes the
+            communication</doc:summary>
+            <doc:description>The organization that physically puts together the
+            communication and publishes it.</doc:description>
+            <doc:example>Harper Collins</doc:example>
+            <doc:example>University Of California Press</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationPlace" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication Place</doc:tooltip>
+            <doc:summary>The location at which the work was
+            published.</doc:summary>
+            <doc:description>The location at which the work was published. This
+            is usually the name of the city in which the publishing house
+            produced the work.</doc:description>
+            <doc:example>New York</doc:example>
+            <doc:example>London</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="communicationType" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Type of communication</doc:tooltip>
+            <doc:summary>The type of personal communication.</doc:summary>
+            <doc:description>The type of personal communication. Could be an
+            email, letter, memo, transcript of conversation either hardcopy or
+            online.</doc:description>
+            <doc:example>memo</doc:example>
+            <doc:example>letter</doc:example>
+            <doc:example>email</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recipient" type="rp:ResponsibleParty" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Recipient</doc:tooltip>
+            <doc:summary>Recipient of the communication</doc:summary>
+            <doc:description>The person, place or thing the personal
+            communication was sent to.</doc:description>
+            <doc:example>Schmedley, Joe</doc:example>
+            <doc:example>jschmedley@lternet.edu</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Map">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>map</doc:tooltip>
+        <doc:summary>This element describes the map that is being cited or
+        cataloged.</doc:summary>
+        <doc:description>This element describes the map that is being cited or
+        cataloged, including its geographic coverage and
+        scale.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="publisher" type="rp:ResponsibleParty" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization that actually publishes the
+            map</doc:summary>
+            <doc:description>The organization that physically puts together the
+            map and publishes it.</doc:description>
+            <doc:example>Harper Collins</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="edition" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Map edition</doc:tooltip>
+            <doc:summary>The edition of the map being described.</doc:summary>
+            <doc:description>The edition field is to document the edition of
+            the map that is being described.</doc:description>
+            <doc:example>Second Edition</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="geographicCoverage" type="cov:GeographicCoverage" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Geographic coverage</doc:tooltip>
+            <doc:summary>Description of the geographic area which the map
+            covers</doc:summary>
+            <doc:description>This element describes the geographic area which
+            the map covers. Could be descriptive text or Cartesian coordinates
+            of the area.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="scale" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Scale</doc:tooltip>
+            <doc:summary>The Map's scale</doc:summary>
+            <doc:description>The Map's scale</doc:description>
+            <doc:example>1:25,000</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AudioVisual">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>audio visual</doc:tooltip>
+        <doc:summary>This reference type is meant to cover all forms of audio
+        and visual media.</doc:summary>
+        <doc:description>This reference type is meant to cover all forms of
+        audio and visual media, including film, video, broadcast, other
+        electronic media.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="publisher" type="rp:ResponsibleParty">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization which actually distributes the video,
+            film, the broadcaster etc...</doc:summary>
+            <doc:description>Organization which actually distributes the video,
+            film, the broadcaster etc...</doc:description>
+            <doc:example>LTER Network Office</doc:example>
+            <doc:example>Public Broadcasting</doc:example>
+            <doc:example>Pacifica Radio</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationPlace" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication Place</doc:tooltip>
+            <doc:summary>The location at which the work was
+            published.</doc:summary>
+            <doc:description>The location at which the work was published. This
+            is usually the name of the city in which the publishing house
+            produced the work.</doc:description>
+            <doc:example>New York</doc:example>
+            <doc:example>London</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="performer" type="rp:ResponsibleParty" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Performer</doc:tooltip>
+            <doc:summary>The performers in the audio visual
+            production</doc:summary>
+            <doc:description>The performers involved in acting, narrating, or
+            shown in the audio visual production.</doc:description>
+            <doc:example>Jim Nabors</doc:example>
+            <doc:example>Sir Lawrence Olivier</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ISBN" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>International Standard Book Number</doc:tooltip>
+            <doc:summary>The unique Internation Standard Book
+            Number</doc:summary>
+            <doc:description>The ISBN, or International Standard Book Number
+            that has been assigned to this literature
+            resource.</doc:description>
+            <doc:example>ISBN 1-861003-11-0</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Generic">
+    <xs:sequence>
+      <xs:element name="publisher" type="rp:ResponsibleParty">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publisher</doc:tooltip>
+            <doc:summary>Organization which actually publishes the
+            reference</doc:summary>
+            <doc:description>The organization which physically puts together
+            the reference and publishes it.</doc:description>
+            <doc:example>Harper Collins</doc:example>
+            <doc:example>University Of California Press</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationPlace" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication Place</doc:tooltip>
+            <doc:summary>The location at which the work was
+            published.</doc:summary>
+            <doc:description>The location at which the work was published. This
+            is usually the name of the city in which the publishing house
+            produced the work.</doc:description>
+            <doc:example>New York</doc:example>
+            <doc:example>London</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="referenceType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Reference Type</doc:tooltip>
+            <doc:summary>The type of reference.</doc:summary>
+            <doc:description>The reference type describes the type of reference
+            this generic type is being used to represent.</doc:description>
+            <doc:example>zine</doc:example>
+            <doc:example>film</doc:example>
+            <doc:example>radio program</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="volume" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Reference volume</doc:tooltip>
+            <doc:summary>The volume of the reference that is part of a
+            series.</doc:summary>
+            <doc:description>The volume field is used to describe the volume
+            number of a reference that is part of a multi-volume series of
+            references.</doc:description>
+            <doc:example>Volume 2</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="numberOfVolumes" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Number of Volumes</doc:tooltip>
+            <doc:summary>Number of volumes in a collection</doc:summary>
+            <doc:description>Number of volumes in a
+            collection</doc:description>
+            <doc:example>"12"</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalPages" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Total reference pages</doc:tooltip>
+            <doc:summary>The total number of pages in the
+            references.</doc:summary>
+            <doc:description>The total pages field is used to describe the
+            total number of pages in the references that is being
+            described.</doc:description>
+            <doc:example>628</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalFigures" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Number of figures in reference</doc:tooltip>
+            <doc:summary>The total number of figures in the
+            reference.</doc:summary>
+            <doc:description>The total figures field is used to describe the
+            total number of figures, diagrams, and plates in the reference that
+            is being documented.</doc:description>
+            <doc:example>45</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalTables" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Number of tables in reference</doc:tooltip>
+            <doc:summary>The total number of tables in a
+            reference.</doc:summary>
+            <doc:description>The total tables field is used to describe the
+            total number of tables that are present in the reference that is
+            being documented.</doc:description>
+            <doc:example>10</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="edition" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>edition</doc:tooltip>
+            <doc:summary>The edition of the generic reference being
+            described.</doc:summary>
+            <doc:description>The edition field is to document the edition of
+            the generic reference type that is being
+            described.</doc:description>
+            <doc:example>Second Edition</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="originalPublication" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Original Publication</doc:tooltip>
+            <doc:summary>References current publication to its
+            original.</doc:summary>
+            <doc:description>Supplemental information about the original
+            publication of the current reference.</doc:description>
+            <doc:example>Date</doc:example>
+            <doc:example>Publisher</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="reprintEdition" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Reprint Edition</doc:tooltip>
+            <doc:summary>Reference for current edition that was originally
+            published under a different title.</doc:summary>
+            <doc:description>Reference for current edition that was originally
+            published under a different title.</doc:description>
+            <doc:example>Stream Research in the LTER Network,
+            1993</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="reviewedItem" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Reviewed Item</doc:tooltip>
+            <doc:summary>Reference types that are reviews of other
+            references.</doc:summary>
+            <doc:description>Use for articles, chapters, audio visual, etc.
+            that are critical review of books, cinema, art, or other
+            works.</doc:description>
+            <doc:example>Structure and Function of an Alpine Ecosystem Niwot
+            Ridge, Colorado Edited by WILLIAM D. BOWMAN and TIMOTHY R.
+            SEASTEDT, University of Colorado, Boulder</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice minOccurs="0">
+        <xs:element name="ISBN" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>International Standard Book Number</doc:tooltip>
+              <doc:summary>The unique Internation Standard Book
+              Number</doc:summary>
+              <doc:description>The ISBN, or International Standard Book Number
+              that has been assigned to this literature
+              resource.</doc:description>
+              <doc:example>ISBN 1-861003-11-0</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="ISSN" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>International Standard Serial Number</doc:tooltip>
+              <doc:summary>The unique Internation Standard Serial
+              Number</doc:summary>
+              <doc:description>The ISSN, or International Standard Serial
+              Number that has been assigned to this literature
+              resource.</doc:description>
+              <doc:example>ISSN 1234-5679</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Thesis">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Thesis as part of a degree</doc:tooltip>
+        <doc:summary>Information about a thesis that has been written as part
+        of a degree requirement and is frequently published in small numbers by
+        the degree awarding institution.</doc:summary>
+        <doc:description>Information about a thesis that has been written as
+        part of a degree requirement and is frequently published in small
+        numbers by the degree awarding institution.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="degree" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Degee name</doc:tooltip>
+            <doc:summary>The name or degree level for which the thesis was
+            completed.</doc:summary>
+            <doc:description>The degree field is used to describe the name or
+            degree level for which the thesis was completed.</doc:description>
+            <doc:example>Ph.D.</doc:example>
+            <doc:example>M.S.</doc:example>
+            <doc:example>Master of Science</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="institution" type="rp:ResponsibleParty">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Degree awarding institution</doc:tooltip>
+            <doc:summary>The name of the degree-awarding
+            institution</doc:summary>
+            <doc:description>The degree institution field is used to name the
+            institution from which the degree was awarded for the thesis being
+            described.</doc:description>
+            <doc:example>Western Washington University</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="totalPages" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Thesis Pages</doc:tooltip>
+            <doc:summary>The total number of pages in the thesis.</doc:summary>
+            <doc:description>The total pages field is used to document the
+            number of pages that are present in the thesis that is being
+            described.</doc:description>
+            <doc:example>356</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Presentation">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Unpublished Presentation</doc:tooltip>
+        <doc:summary>An unpublished presentation from a conference, workshop,
+        workgroup, symposium, etc.</doc:summary>
+        <doc:description>An unpublished presentation from a conference,
+        workshop, workgroup, symposium, etc. It will be provided upon request
+        in either in paper and/or electronic form by contacting the authors. If
+        the presentation was actually published in a proceedings, use the
+        conferenceProceedings type instead.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="conferenceName" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Conference Name</doc:tooltip>
+            <doc:summary>The name of the conference at which this presentation
+            was given.</doc:summary>
+            <doc:description>The name of the conference at which this
+            presentation was given.</doc:description>
+            <doc:example>North American Science Symposium</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="conferenceDate" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Conference Date</doc:tooltip>
+            <doc:summary>The date the conference was held.</doc:summary>
+            <doc:description>The date the conference was
+            held.</doc:description>
+            <doc:example>November 1-6, 1998</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="conferenceLocation" type="rp:Address" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Conference Location</doc:tooltip>
+            <doc:summary>The location where the conference was
+            held.</doc:summary>
+            <doc:description>The location where the conference was
+            held.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-methods.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-methods.xsd
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+  targetNamespace="eml://ecoinformatics.org/methods-2.1.1" 
+  xmlns:txt="eml://ecoinformatics.org/text-2.1.1" 
+  xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+  xmlns:sw="eml://ecoinformatics.org/software-2.1.1" 
+  xmlns:pro="eml://ecoinformatics.org/protocol-2.1.1" 
+  xmlns:rp="eml://ecoinformatics.org/party-2.1.1" 
+  xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" 
+  xmlns:ds="eml://ecoinformatics.org/dataset-2.1.1" 
+  xmlns:cit="eml://ecoinformatics.org/literature-2.1.1" 
+  xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+  xmlns="eml://ecoinformatics.org/methods-2.1.1" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/dataset-2.1.1" schemaLocation="eml-dataset.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/software-2.1.1" schemaLocation="eml-software.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/protocol-2.1.1" schemaLocation="eml-protocol.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/party-2.1.1" schemaLocation="eml-party.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/text-2.1.1" schemaLocation="eml-text.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/literature-2.1.1" schemaLocation="eml-literature.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-methods.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.29 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-methods</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+            The eml-methods module - Methodological information for resources
+          </title>
+            <para>
+            The eml-methods module describes the methods
+            followed in the creation of the dataset, including description of
+            field, laboratory and processing steps, sampling methods and units,
+            quality control procedures.  The eml-methods module is used
+            to describe the <emphasis>actual</emphasis>
+            procedures that are used in the creation or the subsequent
+            processing of a dataset. Likewise, eml-methods is used to describe
+            processes that have been used to define / improve the quality of a
+            data file, or to identify potential problems with the data file.
+            Note that the eml-protocol module is intended to be used to document
+            a <emphasis>prescribed</emphasis> procedure, whereas the eml-method
+            module is used to describe procedures that <emphasis>were actually
+            performed</emphasis>.  The distinction is that the use of the term
+            "protocol" is used in the "prescriptive" sense,
+            and the term "method" is used in the
+            "descriptive" sense.  This distinction allows managers to
+            build a protocol library of well-known, established protocols
+            (procedures), but also document what procedure was truly performed
+            in relation to the established protocol.  The method may have
+            diverged from the protocol purposefully, or perhaps incidentally,
+            but the procedural lineage is still preserved and understandable.
+          </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>All datasets</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="methods" type="MethodsType">
+    <xs:annotation>
+      <xs:documentation>Comment describing your root element</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="MethodsType">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="methodStep" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>method information</doc:tooltip>
+            <doc:summary>Information about the methods employed in collecting
+            or generating a data set or other resource.</doc:summary>
+            <doc:description>The methodStep field allows for repeated sets of
+            elements that document a series of procedures followed to produce a
+            data object. These include text descriptions of the procedures,
+            relevant literature, software, instrumentation, source data and any
+            quality control measures taken.</doc:description>
+            <doc:example>Please see the examples for the
+            sub-fields.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="ProcedureStepType">
+              <xs:sequence>
+                <xs:element name="dataSource" type="ds:DatasetType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>data source</doc:tooltip>
+                      <doc:summary>A source of data used by this
+                      methodStep.</doc:summary>
+                      <doc:description>A source of data used by this methodStep.
+                      </doc:description>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:element>
+              </xs:sequence>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="sampling" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>sampling methods</doc:tooltip>
+            <doc:summary>Description of sampling procedures including the
+            geographic, temporal and taxonomic coverage of the
+            study.</doc:summary>
+            <doc:description>Description of sampling procedures including the
+            geographic, temporal and taxonomic coverage of the
+            study.  See individual elements for more detailed
+            descriptions.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="studyExtent">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Geographic, temporal, taxonomic
+                  coverage</doc:tooltip>
+                  <doc:summary>A description of the geographic area sampled
+                  (geographic coverage), the sampling frequency (temporal
+                  coverage), and living organisms sampled (taxonomic
+                  coverage.</doc:summary>
+                  <doc:description>The field studyExtent represents both a
+                  specific sampling area and the sampling frequency (temporal
+                  boundaries, frequency of occurrence). The geographic
+                  studyExtent is usually a surrogate (representative area of)
+                  for the larger area documented in the "studyAreaDescription".
+                  The studyExtent can be entered either in non-structured
+                  textual form or using the structure of the coverage
+                  element.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:choice maxOccurs="unbounded">
+                  <xs:element name="coverage" type="cov:Coverage">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>coverage</doc:tooltip>
+                        <doc:summary>A description of the geographic area sampled
+                        (geographic coverage), the sampling frequency (temporal
+                        coverage), and living organisms sampled (taxonomic
+                        coverage.</doc:summary>
+                        <doc:description>The field studyExtent represents both a
+                        specific sampling area and the sampling frequency (temporal
+                        boundaries, frequency of occurrence). The geographic
+                        studyExtent is usually a surrogate (representative area of)
+                        for the larger area documented in the "studyAreaDescription".
+                        The studyExtent can be entered either in non-structured
+                        textual form or using the structure of the coverage
+                        element.  See eml-coverage for more
+                        information.</doc:description>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="description" type="txt:TextType">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Text description of the
+                        coverage</doc:tooltip>
+                        <doc:summary>A textual description of the specific
+                        areas sampled (geographic coverage), the sampling
+                        frequency (temporal coverage), and groups of living
+                        organisms sampled (taxonomic coverage).</doc:summary>
+                        <doc:description>The coverage field allows for a
+                        textual description of the specific sampling area, the
+                        sampling frequency (temporal boundaries, frequency of
+                        occurrence), and groups of living organisms sampled
+                        (taxonomic coverage).</doc:description>
+                        <doc:example>The study was conducted on the North
+                        Platte River, starting 6 miles downstream and ending 9
+                        miles downstream of the route 132 bridge in Evanston,
+                        ND.</doc:example>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:choice>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="samplingDescription" type="txt:TextType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Sampling methods and procedures</doc:tooltip>
+                  <doc:summary>A description of sampling methods and
+                  procedures</doc:summary>
+                  <doc:description>The samplingDescription field allows for a
+                  text-based/human readable description of the sampling
+                  procedures used in the research project. The content of this
+                  element would be similar to a description of sampling
+                  procedures found in the methods section of a journal
+                  article.</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="spatialSamplingUnits" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Spatial sampling units</doc:tooltip>
+                  <doc:summary>Spatial sampling units represent the plots
+                  sampled.</doc:summary>
+                  <doc:description>A spatial sampling unit describes the
+                  specific geographic areas sampled. In the case of a study in
+                  which the measurements from several disbursed point
+                  collection devices are aggregated, then the sampling unit
+                  would be the area of that aggregation. Spatial sampling units
+                  can either be described by filling out the structured
+                  coverage element or by reference to the values in a data
+                  table (usually a GIS layer)</doc:description>
+                  <doc:example>If a researcher places a single light source at
+                  a specific point in a research location in order to attract
+                  insects to derive an estimate of the insect population, then
+                  the sampling unit is the area illuminated by the light source
+                  (in actual practice there might be multiple sampling units in
+                  this case since different species have different attraction
+                  rates).</doc:example>
+                  <doc:example>The bounding box of a specific 3-meter square
+                  plot.</doc:example>
+                  <doc:example>The location of a weather station.</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:choice maxOccurs="unbounded">
+                  <xs:element name="referencedEntityId">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>The identifier of a spatial sampling
+                        entity.</doc:tooltip>
+                        <doc:summary>The identifier of an entity described in
+                        the entity module. This is usually a GIS
+                        layer.</doc:summary>
+                        <doc:description>A value of a referencedEntityId
+                        element is a reference to the identifier of the entity
+                        module that provides the metadata for a data table
+                        (RDBMS, GIS or ascii text) that has the actual spatial
+                        sampling unit values. The referencedEntityId field is
+                        an indirect pointer to the actual values. The
+                        referencedEntityId can be thought of as a foreign key
+                        in a relational database.</doc:description>
+                        <doc:example>x</doc:example>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                  <xs:element name="coverage" type="cov:GeographicCoverage">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>sampling unit location</doc:tooltip>
+                        <doc:summary>Structured description of each sampling unit
+                      location</doc:summary>
+                        <doc:description>Structured description of each sampling
+                      unit location</doc:description>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:choice>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="citation" type="cit:CitationType" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>citation</doc:tooltip>
+                  <doc:summary>Literature citation relating to the sampling
+               procedures used.</doc:summary>
+                  <doc:description>The citation field allows to either reference
+               a literature resource or enter structured literature
+               information</doc:description>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="qualityControl" type="ProcedureStepType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Quality Control</doc:tooltip>
+            <doc:summary>Information on possible errors or on the quality of a
+            data set.</doc:summary>
+            <doc:description>The qualityControl field provides a location for
+            the description of actions taken to either control or assess the
+            quality of data resulting from the associated method step. A
+            quality control description should identify a quality goal and
+            describe prescriptive steps taken to ensure that the data meet
+            those standards and/or postscriptive steps taken to assess the
+            extent to which they are met. A quality control statement is
+            associated with the methodStep that could have affected the
+            targeted quality goal.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ProcedureStepType">
+    <xs:sequence>
+      <xs:sequence>
+        <xs:element name="description" type="txt:TextType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Methods description</doc:tooltip>
+              <doc:summary>Description of the methods employed in collecting or
+              generating a data set or other resource or in quality control and
+              assurance.</doc:summary>
+              <doc:description>The description field allows for repeated text
+              that describes the methodology for a project, experiment, or
+              particular data table or to describe the steps taken to control
+              or assure the quality of the data. Likewise, a literature
+              citation may be provided that describes the methodology that was
+              employed. Or the information my be provided by either referencing
+              a protocol resource or entering the structured protocol
+              information</doc:description>
+              <doc:example>1.Collect tissues from algae of
+              interest. a. We are currently
+              collecting Egregia menziezii, Mazzaella splendens, M. flaccida,
+              Hedophyllum sessile, Postelsia palmaeformis and Fucus gardneri.We
+              stopped collecting Neorhodomela larix and Odonthalia floccosa
+              because they can be heavily fouled and we feared that would skew
+              the results. b. We collect a 7-10 cm
+              blade or branch from each plant. For Egregia, try to sample
+              small, young plants or take the base of the blade. For Postelsia,
+              take a few of the blades. The other plants are small enough so a
+              whole blade can be taken.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="citation" type="cit:CitationType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>citation</doc:tooltip>
+                <doc:summary>Literature citation relating to the methods
+              used.</doc:summary>
+                <doc:description>The citation field allows to either reference a
+              literature resource or enter structured literature
+              information</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="protocol" type="pro:ProtocolType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Protocol</doc:tooltip>
+                <doc:summary>Protocol description relating to the methods
+              used.</doc:summary>
+                <doc:description>The protocol field is used to either reference a
+              protocol resource or describe methods and identify the processes
+              that have been used to define / improve the quality of a data
+              file, also used to identify potential problems with the data
+              file.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+      <xs:element name="instrumentation" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Instrumentation</doc:tooltip>
+            <doc:summary>Instruments used for measurement and recording
+            data.</doc:summary>
+            <doc:description>The Instrumentation field allows the description
+            of any instruments used in the data collection or quality control
+            and quality assurance. The description should include vendor, model
+            number, optional equipment, etc.</doc:description>
+            <doc:example>LACHAT analyzer, model XYX.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="software" type="sw:SoftwareType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Software</doc:tooltip>
+            <doc:summary>Software used in the processing of data.</doc:summary>
+            <doc:description>The software element allows reference to any
+            software used to process data.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="subStep" type="ProcedureStepType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>substep</doc:tooltip>
+            <doc:summary/>
+            <doc:description>This fields allows the nesting of additional method
+            steps within this step.  This is useful for hierarchical method
+            descriptions.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-party.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-party.xsd
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns="eml://ecoinformatics.org/party-2.1.1" targetNamespace="eml://ecoinformatics.org/party-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-party.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.55 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-party</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+            The eml-party module - People and organization information
+          </title>
+            <para>
+            The eml-party module describes a responsible party 
+            and is typically used to name the creator of a
+            resource or metadata document. A responsible party may be 
+			an individual person, an organization or a named position within
+			an organization. The eml-party module contains detailed contact
+            information. It is used throughout the other EML modules where
+            detailed contact information is needed.
+          </para>
+            <para>
+            The eml-party module, like other modules, may be
+            "referenced" via the &lt;references&gt; tag.  This allows
+            a party to be described once, and then used as a reference in
+            other locations within the EML document via its ID.
+          </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all datasets</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:complexType name="ResponsibleParty">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Responsible party</doc:tooltip>
+        <doc:summary>The individual, organization, or role associated with a
+        resource.</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>The ResponsibleParty Type contains 
+        elements that are used to describe the person, organization or
+        position within an organization that is associated in some way with the
+        resource. It is intended to be used to fully document contact
+        information for many types of associations, such as owner, manager,
+        steward, curator, etc.</para>
+            <para>Note that the content model for a responsible party type 
+        allows a sequence of choices for the first
+        element(s): &lt;individualName&gt;, &lt;organizationName&gt; and/or &lt;positionName&gt;. 
+        This means that a parent element (e.g., creator) may use combinations of the 3 sub-elements 
+        to make up a single logical party. For example, a creator with only
+                the individualName of 'Joe Smith' is NOT the same as a
+                creator with the individualName of 'Joe Smith' and the
+                organizationName of 'NSF'. To include both a positionName and
+                 an organizationName as children of a &lt;contact&gt; implies that anyone 
+                currently occupying that positionName at that organizationName 
+                is an appropriate contact.
+                The positionName should not be
+                used in conjunction with individualName unless only that specific
+                individual at that position would be considered appropriate for that
+                designation.   </para>
+          </section>
+        </doc:description>
+        <doc:example>Please see the examples for the particular
+        subfields.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="individualName" type="Person">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Individual Name</doc:tooltip>
+                <doc:summary>The full name of the person being
+                described</doc:summary>
+                <doc:description>
+                  <section xmlns="">
+                    <para>The individualName
+                field contains subfields so that  a person's name can be broken
+                down into               parts.</para>
+                    <para>Note that the the content model for the containing type 
+        allows a sequence of choices for the first
+        element(s): &lt;individualName&gt;, &lt;organizationName&gt; and/or &lt;positionName&gt;. 
+        This means that a parent element (e.g., creator) may use combinations of the 3 sub-elements 
+        to make up a single logical party. For example, a creator with only
+                the individualName of 'Joe Smith' is NOT the same as a
+                creator with the individualName of 'Joe Smith' and the
+                organizationName of 'NSF'. To include both a positionName and
+                 an organizationName as children of a &lt;contact&gt; implies that anyone 
+                currently occupying that positionName at that organizationName 
+                is an appropriate contact.
+                The positionName should not be
+                used in conjunction with individualName unless only that specific
+                individual at that position would be considered appropriate for that
+                designation.   </para>
+                  </section>
+                </doc:description>
+                <doc:example>Because this is an 'elementOnly' field, please
+                look at the examples for the subfields 'givenName' and
+                'surName'.</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="organizationName" type="res:i18nNonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Organization name</doc:tooltip>
+                <doc:summary>The full name of the organization being
+                described</doc:summary>
+                <doc:description>
+                  <section xmlns="">
+                    <para>The responsible party field contains the full
+                name of the organization that is associated with the resource.
+                This field is intended to describe which institution or overall
+                organization is associated with the resource being described.
+               </para>
+                    <para>Note that the the content model for the containing type 
+        allows a sequence of choices for the first
+        element(s): &lt;individualName&gt;, &lt;organizationName&gt; and/or &lt;positionName&gt;. 
+        This means that a parent element (e.g., creator) may use combinations of the 3 sub-elements 
+        to make up a single logical party. For example, a creator with only
+                the individualName of 'Joe Smith' is NOT the same as a
+                creator with the individualName of 'Joe Smith' and the
+                organizationName of 'NSF'. To include both a positionName and
+                 an organizationName as children of a &lt;contact&gt; implies that anyone 
+                currently occupying that positionName at that organizationName 
+                is an appropriate contact.
+                The positionName should not be
+                used in conjunction with individualName unless only that specific
+                individual at that position would be considered appropriate for that
+                designation.   </para>
+                  </section>
+                </doc:description>
+                <doc:example>National Center for Ecological Analysis and
+                Synthesis</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="positionName" type="res:i18nNonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Position Name</doc:tooltip>
+                <doc:summary>The name of the title or position associated with
+                the resource.</doc:summary>
+                <doc:description>
+                  <section xmlns="">
+                    <para>This field is intended to be used instead of a
+                particular person or full organization name. If the associated
+                person who holds the role changes frequently, then Position
+                Name would be used for consistency. </para>
+                    <para>Note that the the content model for the containing type 
+        allows a sequence of choices for the first
+        element(s): &lt;individualName&gt;, &lt;organizationName&gt; and/or &lt;positionName&gt;. 
+        This means that a parent element (e.g., creator) may use combinations of the 3 sub-elements 
+        to make up a single logical party. For example, a creator with only
+                the individualName of 'Joe Smith' is NOT the same as a
+                creator with the individualName of 'Joe Smith' and the
+                organizationName of 'NSF'. To include both a positionName and
+                 an organizationName as children of a &lt;contact&gt; implies that anyone 
+                currently occupying that positionName at that organizationName 
+                is an appropriate contact.
+                The positionName should not be
+                used in conjunction with individualName unless only that specific
+                individual at that position would be considered appropriate for that
+                designation.   </para>
+                  </section>
+                </doc:description>
+                <doc:example>Niwot Ridge Data Manager</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="address" type="Address" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Contact address</doc:tooltip>
+              <doc:summary>The full address information for a given responsible
+              party entry.</doc:summary>
+              <doc:description>The address field is a container for multiple
+              subfields that describe the physical or electronic address of the
+              responsible party for a resource.</doc:description>
+              <doc:example>Please see the subfield examples.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="phone" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Phone</doc:tooltip>
+              <doc:summary>Information about the contact's
+              telephone</doc:summary>
+              <doc:description>The phone field describes information about the
+              responsible party's telephone, be it a voice phone, fax, or
+              TTD/TTY type telephone. This field contains an attribute used to
+              identify the type.</doc:description>
+              <doc:example>805-555-2500</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="phonetype" type="xs:string" use="optional" default="voice">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Phone type</doc:tooltip>
+                      <doc:summary>The type of the phone to which this number
+                      applies</doc:summary>
+                      <doc:description>This attribute gives the type of phone
+                      to which this number applies. By default, this is assumed
+                      to be of type "voice", but other possibilities include
+                      "facsimile" and "tdd".</doc:description>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="electronicMailAddress" type="res:i18nNonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Email address</doc:tooltip>
+              <doc:summary>The email address of the contact.</doc:summary>
+              <doc:description>The electronic mail address is the email address
+              for the party. It is intended to be an Internet SMTP email
+              address, which should consist of a username followed by the @
+              symbol, followed by the email server domain name address. Other
+              address types are allowable.</doc:description>
+              <doc:example>my-email@mydomain.edu</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="onlineUrl" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Online Link</doc:tooltip>
+              <doc:summary>A link to associated online information, usually a
+              web site.</doc:summary>
+              <doc:description>A link to associated online information, usually
+              a web site. When the party represents an organization, this is
+              the URL to a website or other online information about the
+              organization. If the party is an individual, it might be their
+              personal web site or other related online information about the
+              party.</doc:description>
+              <doc:example>http://www.yourdomain.edu/~doe</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="userId" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>User Identifier</doc:tooltip>
+              <doc:summary>An identifier that links this party to a
+              directory of personnel</doc:summary>
+              <doc:description>An identifier that links this party to a
+              directory of personnel.  Although specific contact information
+              for a party might change, the underlying correspondence to a
+              real individual does not.  This identifier provides a pointer
+              within a personnel directory that may contain further, and possibly
+              more current, information about the party.
+              </doc:description>
+              <doc:example>uid=jtown,o=NCEAS,dc=ecoinformatics,dc=org</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="directory" type="xs:string" use="required">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Directory</doc:tooltip>
+                      <doc:summary>The directory system within which the
+                      directoryId can be retrieved.</doc:summary>
+                      <doc:description>This attribute names the directory system
+                      to which this userId applies. This will generally
+                      be a URL that shows how to look up information, for
+                      example an LDAP url. However, it could also be a
+                      non-parsable description of the directory system if
+                      that is all that is available.</doc:description>
+                      <doc:example>
+                        ldap:///ldap.ecoinformatics.org/dc=ecoinformatics,dc=org
+                      </doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="Person">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Person</doc:tooltip>
+        <doc:summary>The full name of the individual associated with the
+        resource.</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>The person Type is used to enter the salutation, and 
+        two types of name parts for an individual associated with the
+        resource. It uses these three subfields to help parse the person's
+        entire name.</para>
+            <para> The two elements, &lt;givenName&gt;  and  &lt;surName&gt;,
+             allow parsing of many types of names, even though distinct elements 
+             do not exist for concepts like "middle name" and "compound surname".
+        &lt;givenName&gt; should be used for parts of the name that are often
+        shortened to a first initial, or are not used for ordering, and typically includes
+        first and middle names.
+        The &lt;surName&gt; field is intended to be used for the part of the name that
+        is generally displayed in its entirety and/or is alphabetized or otherwise ordered
+        when appropriate. Note that only one
+        &lt;surName&gt; is allowed, and is required, while &lt;givenName&gt;s are 
+       optional and unbounded.    </para>
+            <para>The arrangement and content of the sub-elements is entirely 
+       up to the EML document's author, who presumably has first-hand knowledge of 
+       how the names are to be constructed. For example, if element position is important 
+       (e.g., the list of a book's        authors), then
+       EML authors should put the creators in that order. If it is appropriate for a
+       resource to have its creators sorted alphabetically, then the EML author
+       should construct the name parts so that the&lt;surName&gt; field may be used for
+       this purpose. At this time, EML is not able to express cultural 
+       conventions so that authors may indicate the correct order for 
+       &lt;givenName&gt;s and &lt;surName&gt; when the whole name is expressed. 
+       However support for international names
+       is under consideration for a future version of 
+       EML, along with other internationalization features.
+     </para>
+          </section>
+        </doc:description>
+        <doc:example>Please see the examples within each
+        subfield.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="salutation" type="res:i18nNonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Salutation</doc:tooltip>
+            <doc:summary>The salutation used to address an
+            individual</doc:summary>
+            <doc:description>The salutation field is used in addressing an
+            individual with a particular title, such as Dr., Ms., Mrs., Mr.,
+            etc.</doc:description>
+            <doc:example>Dr.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="givenName" type="res:i18nNonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Given name</doc:tooltip>
+            <doc:summary>The given name of the individual.</doc:summary>
+            <doc:description>The given name field can be used for first name of
+            the individual associated with the resource, or for any other names
+            that are not intended to be alphabetized, (as appropriate). Note that 
+            while it is possible  to include all given names in one field (as in the
+            example below), it may be not be good practice to do so. For example, if an 
+            XSL transformation stylesheet were to abbreviate the content of a 
+            givenName to just the first initial, a givenName element that contained 
+            more than one name would not be transformed correctly. </doc:description>
+            <doc:example>Juan Luis</doc:example>
+            <doc:example>Jane</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="surName" type="res:i18nNonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Last name</doc:tooltip>
+            <doc:summary>The last name of the individual.</doc:summary>
+            <doc:description>The surname field is used for the last name of the
+            individual associated with the resource. This is typically the family name
+            of an individual, for example, the name by which s/he is referred to in citations.
+            </doc:description>
+            <doc:example>San Gil</doc:example>
+            <doc:example>Curtis-Ainsworth</doc:example>
+            <doc:example>Tao</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Address">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Address</doc:tooltip>
+        <doc:summary>The full address of the resposible party.</doc:summary>
+        <doc:description>The address field is provides detailed information for
+        communicating with a party contact via electronic mail or postal mail,
+        including the physical delivery location.</doc:description>
+        <doc:example>Please see the examples for each subfield</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="deliveryPoint" type="res:i18nNonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Delivery point</doc:tooltip>
+              <doc:summary>The location for postal deliveries.</doc:summary>
+              <doc:description>The delivery point field is used for the
+              physical address for postal communication. This field is used to
+              accommodate the many different international conventions that are
+              the equivalent to a U.S. 'street address'.</doc:description>
+              <doc:example>7209 Coast Drive, Building 44</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="city" type="res:i18nNonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>City</doc:tooltip>
+              <doc:summary>The name of the city for the contact.</doc:summary>
+              <doc:description>The city field is used for the city name of the
+              contact associated with a particular resource.</doc:description>
+              <doc:example>San Francisco</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="administrativeArea" type="res:i18nNonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Administrative area</doc:tooltip>
+              <doc:summary>The political area of a country.</doc:summary>
+              <doc:description>The administrative area field is the equivalent
+              of a 'state' in the U.S., or Province in Canada. This field is
+              intended to accommodate the many types of international
+              administrative areas.</doc:description>
+              <doc:example>Colorado</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="postalCode" type="res:i18nNonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Postal code</doc:tooltip>
+              <doc:summary>The postal code used for routing to an
+              address.</doc:summary>
+              <doc:description>The postal code is equivalent to a U.S. zip
+              code, or the number used for routing to an international address.
+              The U.S. postal code should include the 5 digit code plus the 4
+              digit extension.</doc:description>
+              <doc:example>93106-2231</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="country" type="res:i18nNonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Country</doc:tooltip>
+              <doc:summary>The name of the country for the contact's
+              address.</doc:summary>
+              <doc:description>The country field is used for the name of the
+              contact's country.</doc:description>
+              <doc:example>U.S.A.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:element name="party" type="ResponsibleParty">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Responsible party</doc:tooltip>
+        <doc:summary>An individual, organization, or role.
+        </doc:summary>
+        <doc:description>The responsible party contains multiple
+        subfields that are used to describe a person, organization, or
+        position within an organization.
+        It is intended to be used to fully document contact
+        information for many types of associations, such as owner, manager,
+        steward, curator, etc.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:simpleType name="RoleType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Role</doc:tooltip>
+        <doc:summary>The classification of the associated person or
+        organization.</doc:summary>
+        <doc:description>The role code field provides information on how a
+        person or organization is related to a resource. There may be many
+        people associated, including an 'originator' of a dataset, an 'author',
+        'editor', or 'publisher' of a literature resource, or an organization
+        that is a 'distributor'. the full list of choices is included in the
+        example.</doc:description>
+        <doc:example>author, contentProvider, custodianSteward, distributor,
+        editor, metadataProvider, originator, pointOfContact,
+        principalInvestigator, processor, publisher, or user.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="contentProvider"/>
+          <xs:enumeration value="custodianSteward"/>
+          <xs:enumeration value="owner"/>
+          <xs:enumeration value="user"/>
+          <xs:enumeration value="distributor"/>
+          <xs:enumeration value="metadataProvider"/>
+          <xs:enumeration value="originator"/>
+          <xs:enumeration value="pointOfContact"/>
+          <xs:enumeration value="principalInvestigator"/>
+          <xs:enumeration value="processor"/>
+          <xs:enumeration value="publisher"/>
+          <xs:enumeration value="author"/>
+          <xs:enumeration value="editor"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string"/>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-physical.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-physical.xsd
@@ -1,0 +1,1348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:cit="eml://ecoinformatics.org/literature-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:acc="eml://ecoinformatics.org/access-2.1.1" xmlns="eml://ecoinformatics.org/physical-2.1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="eml://ecoinformatics.org/physical-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/literature-2.1.1" schemaLocation="eml-literature.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/access-2.1.1" schemaLocation="eml-access.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-physical.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+
+     For Details: http://knb.ecoinformatics.org/
+        '$Author: obrien $'
+          '$Date: 2009-03-05 22:33:04 $'
+      '$Revision: 1.82 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-physical</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>The eml-physical module - Physical file format</title>
+            <para>
+        The eml-physical module describes the external
+        and internal physical characteristics of a data object as well as the
+        information required for its distribution. Examples of the external
+        physical characteristics of a data object would be the filename,
+        size, compression, encoding methods, and authentication of a file
+        or byte stream.  Internal physical characteristics describe the
+        format of the data object being described.  Both named binary or
+        otherwise proprietary formats can be cited (e.g., Microsoft Access
+        2000), or text formats can be precisely described (e.g., ASCII text
+        delimited with commas).  For these text formats, it also includes the
+        information needed to parse the data object to extract the entity
+        and its attributes from the data object.  Distribution information
+        describes how to retrieve the data object.  The retrieval information
+        can be either online (e.g., a URL or other connection information)
+        or offline (e.g., a data object residing on an archival tape).
+        </para>
+            <para>
+          The eml-physical module, like other modules, may be
+          "referenced" via the &lt;references&gt; tag.  This
+          allows a physical document to be described once, and then
+          used as a reference in other locations within the EML document
+          via its ID.
+        </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>Any data object that is being described by EML
+        needs this information so the entities and attributes that reside
+        with in the data object can be extracted. </doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="physical" type="PhysicalType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Physical structure</doc:tooltip>
+        <doc:summary>Physical structure of an entity or entities.</doc:summary>
+        <doc:description>The content model for physical is a CHOICE between
+        "references" and all of the elements that let you describe the
+        internal/external characteristics and distribution of a data object
+        (e.g., dataObject, dataFormat, distribution.) A physical element can
+        contain a reference to an physical element defined elsewhere. Using
+        a reference means that the referenced physical is identical, not just
+        in name but identical in its complete description.  </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="PhysicalType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Physical structure</doc:tooltip>
+        <doc:summary>Physical structure of an entity or entities.</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>The eml-physical module describes the physical characteristics of a 
+            data object 
+        and the information required for its distribution. External physical characteristics
+        include  the filename, size, compression, encoding methods, and authentication 
+        of a file or byte stream. Internal physical characteristics describe the format of 
+        the data object. Proprietary formats can be cited (e.g., Microsoft Access 2000), 
+        or text formats can be precisely described (e.g., ASCII text delimited with commas). 
+        The module includes the information needed to parse the text data object to extract 
+        the entity and its attributes. Distribution information describes how to retrieve the 
+        data object, either as online (a URL or connection definition), offline (e.g., a data 
+        object residing on an archival tape), or inline (i.e., the data are included with the 
+        metadata).</para>
+            <para>Like many other EML elements, a physical Type can
+        contain a reference to another physical element defined elsewhere in the document
+        instead of a description of the resource.        Using
+        a reference means that the referenced physical is identical, not just
+        in name but identical in its complete description.  </para>
+          </section>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="objectName" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Data object name</doc:tooltip>
+              <doc:summary>The name of the data object.
+              </doc:summary>
+              <doc:description>The name of the data object.  This is
+              possibly distinct from the entity name in that one physical
+              object can contain multiple entities, even though that is not
+              a recommended practice.  The objectName often is the filename
+              of a file in a file system or that is accessible on the network.
+              </doc:description>
+              <doc:example>rainfall-sev-2002-10.txt</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="size" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Data object size</doc:tooltip>
+              <doc:summary>Describes the physical size of the
+                    data object.</doc:summary>
+              <doc:description>This element contains information of the
+                    physical size of the entity, by default represented in
+                    bytes unless the unit attribute is provided to change
+                    the units.</doc:description>
+              <doc:example>134</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="unit" use="optional" default="byte">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Unit of measurement</doc:tooltip>
+                      <doc:summary>Unit of measurement for the entity
+                            size, by default byte</doc:summary>
+                      <doc:description>This element gives the unit of
+                            measurement for the size of the entity, and is
+                            by default a byte.</doc:description>
+                      <doc:example>byte</doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="authentication" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Authentication value</doc:tooltip>
+              <doc:summary>A value, typically a checksum, used to
+                    authenticate that the bitstream delivered to the user is
+                    identical to the original.</doc:summary>
+              <doc:description>This element describes authentication
+                    procedures or techniques, typically by giving a checksum
+                    value for the object. The method used to compute the
+                    authentication value (e.g., MD5) is listed in the method
+                    attribute.</doc:description>
+              <doc:example>f5b2177ea03aea73de12da81f896fe40</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="method" type="xs:string" use="optional">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Authentication method</doc:tooltip>
+                      <doc:summary>The method used to calculate an
+                            authentication checksum.</doc:summary>
+                      <doc:description>This element names the method used
+                            to calculate and authentication checksum that can
+                            be used to validate a bytestream. Typical checksum
+                            methods include MD5 and CRC.</doc:description>
+                      <doc:example>MD5</doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="compressionMethod" type="res:NonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Compression Method</doc:tooltip>
+                <doc:summary>Name of a compression method applied
+                </doc:summary>
+                <doc:description>This element lists a compression method used
+                to compress the object, such as zip, compress, etc. Compression
+                and encoding methods must be listed in the order in which they
+                were applied, so that decompression and decoding should
+                occur in the reverse order of the listing. For example,
+                if a file is compressed using zip and then encoded using
+                MIME base64, the compression method would be listed first
+                and the encoding method second.</doc:description>
+                <doc:example>zip</doc:example>
+                <doc:example>gzip</doc:example>
+                <doc:example>compress</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="encodingMethod" type="res:NonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Encoding Method</doc:tooltip>
+                <doc:summary>Name of a encoding method applied
+                </doc:summary>
+                <doc:description>This element lists a encoding method used
+                to encode the object, such as base64, BinHex, etc. Compression
+                and encoding methods must be listed in the order in which they
+                were applied, so that decompression and decoding should
+                occur in the reverse order of the listing. For example,
+                if a file is compressed using zip and then encoded using
+                MIME base64, the compression method would be listed first
+                and the encoding method second.</doc:description>
+                <doc:example>base64</doc:example>
+                <doc:example>uuencode</doc:example>
+                <doc:example>binhex</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="characterEncoding" type="res:NonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Character Encoding</doc:tooltip>
+              <doc:summary>Contains the name of the character encoding
+                    used for the data.</doc:summary>
+              <doc:description>This element contains the name of the
+                    character encoding. This is typically ASCII or UTF-8, or
+                    one of the other common encodings.</doc:description>
+              <doc:example>UTF-8</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="dataFormat">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Data format</doc:tooltip>
+              <doc:summary>Describes the internal physical format
+            of a data object.</doc:summary>
+              <doc:description>This element is the parent which is a CHOICE
+            between four possible internal physical formats
+            which describe the internal
+            physical characteristics of the data object.  Using this
+            information the user should be able parse physical object to
+              extract the entity and its attributes. Note that this is
+            the format of the physical object itself.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="textFormat">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Text Format</doc:tooltip>
+                    <doc:summary>Description of a text formatted object
+                    </doc:summary>
+                    <doc:description>Description of a text formatted object.
+                    The description includes detailed parsing instructions for
+                    extracting attributes from the bytestream for simple
+                    delimited file formats (e.g., CSV), fixed format files
+                    that use fixed columns for attribute locations, and
+                    mixtures of the two.  It also supports records that
+                    span multiple lines.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="numHeaderLines" type="xs:int" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Number of header lines</doc:tooltip>
+                          <doc:summary>Number of header lines preceding
+                          data.</doc:summary>
+                          <doc:description>Number of header lines preceding
+                          data.  Lines are determined by the
+                          physicalLineDelimiter, or if it is absent, by the
+                          recordDelimiter.  This value indicated the
+                          number of header lines that should be skipped
+                          before starting to parse the data.
+                          </doc:description>
+                          <doc:example>4</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="numFooterLines" type="xs:int" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Number of footer lines</doc:tooltip>
+                          <doc:summary>Number of footer lines following
+                          data.</doc:summary>
+                          <doc:description>Number of footer lines following
+                          data.  Lines are determined by the
+                          physicalLineDelimiter, or if it is absent, by the
+                          recordDelimiter.  This value indicated the
+                          number of footer lines that should be skipped
+                          after parsing the data. If this value is omitted,
+                          parsers should assume the data continues to the end
+                          of the data stream.</doc:description>
+                          <doc:example>4</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="recordDelimiter" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Record delimiter character</doc:tooltip>
+                          <doc:summary>Character used to delimit
+                          records.</doc:summary>
+                          <doc:description>This element specifies the record
+                          delimiter character when the format is text. The
+                          record delimiter is usually a linefeed (\n) on UNIX, a
+                          carriage return (\r) on MacOS, or both (\r\n) on
+                          Windows/DOS. Multiline records are usually delimited
+                          with two line ending characters, for example on UNIX
+                          it would be two linefeed characters (\n\n). As record
+                          delimiters are often non-printing characters, one can
+                          use either the special value "\n" to represent a
+                          linefeed (ASCII 0x0a) and "\r" to represent a carriage
+                          return (ASCII 0x0d).  Alternatively, one can use the
+                          hex value to represent character values (e.g., 0x0a).
+                          </doc:description>
+                          <doc:example>\n\r</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="physicalLineDelimiter" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Physical line delimiter character
+                          </doc:tooltip>
+                          <doc:summary>Character used to delimit
+                          physical lines.</doc:summary>
+                          <doc:description>This element specifies the physical
+                          line delimiter character when the format is text. The
+                          line delimiter is usually a linefeed (\n) on UNIX, a
+                          carriage return (\r) on MacOS, or both (\r\n) on
+                          Windows/DOS. Multiline records are usually delimited
+                          with two line ending characters, for example on UNIX
+                          it would be two linefeed characters (\n\n). As line
+                          delimiters are often non-printing characters, one can
+                          use either the special value "\n" to represent a
+                          linefeed (ASCII 0x0a) and "\r" to represent a carriage
+                          return (ASCII 0x0d).  Alternatively, one can use the
+                          hex value to represent character values (e.g., 0x0a).
+                          If this value is not provided, processors should
+                          assume that the physical line delimiter is the same
+                          as the record delimiter.
+                          </doc:description>
+                          <doc:example>\n\r</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="numPhysicalLinesPerRecord" type="xs:unsignedInt" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Physical lines per record</doc:tooltip>
+                          <doc:summary>The number of physical lines in the file
+                          spanned by a single logical data record.</doc:summary>
+                          <doc:description>A single logical data record may be
+                          written over several physical lines in a file, with
+                          no special marker to indicate the end of a record. In
+                          such cases, it is necessary to know the number of
+                          lines per record in order to correctly read
+                          them. If this value is not provided, processors should
+                          assume that records are wholly contained on one
+                          physical line.  If the value is greater than 1, then
+                          processors should examine the lineNumber field for
+                          each attribute to determine which line of the
+                          record contains the information.</doc:description>
+                          <doc:example>3</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="maxRecordLength" type="xs:unsignedLong" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Maximum record length</doc:tooltip>
+                          <doc:summary>The maximum number of characters in any
+                          record in the physical file.
+                          </doc:summary>
+                          <doc:description>The maximum number of characters
+                          in any record in the physical file.  For delimited
+                          files, the record length varies and this is not
+                          particularly useful.  However, for fixed format files
+                          that do not contain record delimiters, this field is
+                          critical to tell processors when one record stops
+                          and another begins.</doc:description>
+                          <doc:example>597</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="attributeOrientation">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Orientation of attributes</doc:tooltip>
+                          <doc:summary>Orientation of attributes.</doc:summary>
+                          <doc:description> Specifies whether the attributes
+                          described in the physical stream are found in
+                          columns or rows. The valid values are column or row.
+                          If set to 'column', then the attributes are in
+                          columns. If set to 'row', then the attributes
+                          are in rows.  Row orientation is rare,  but some
+                          systems such as SPlus and R utilize it.
+
+                          For example, some data with column orientation:
+                          DATE          PLOT           SPECIES
+                          2002-01-15    hfr5           acer rubrum
+                          2002-01-15    hfr5           acer xxxx
+
+                          The same data in a rowMajor table:
+                          DATE   2002-01-15
+                          PLOT   hfr5
+                          SPECIES acer rubrum  acer xxxx
+                          </doc:description>
+                          <doc:example>column</doc:example>
+                          <doc:example>row</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="column"/>
+                          <xs:enumeration value="row"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:choice>
+                      <xs:element name="simpleDelimited">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Simple delimited format
+                            </doc:tooltip>
+                            <doc:summary>A simple delimited format.
+                            </doc:summary>
+                            <doc:description>A simple delimited format that
+                            uses one of a series of delimiters to indicate
+                            the ends of fields in the data stream. More
+                            complex formats such as fixed format or mixed
+                            delimited and fixed formats can be described using
+                            the "complex" element.
+                            </doc:description>
+                          </xs:appinfo>
+                        </xs:annotation>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="fieldDelimiter" type="xs:string" maxOccurs="unbounded">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>Field Delimiter character
+                                  </doc:tooltip>
+                                  <doc:summary>Character used to delimit the
+                                  end of an attribute</doc:summary>
+                                  <doc:description>This element specifies
+                                  a character to be used in the object for
+                                  indicating the ending column for an attribute.
+                                  The delimiter character itself is not part
+                                  of the attribute value, but rather is present
+                                  in the column following the last character
+                                  of the value. Typical delimiter characters
+                                  include commas, tabs, spaces, and semicolons.
+                                  The only time the fieldDelimiter character is
+                                  not interpreted as a delimiter is if it
+                                  is contained in a quoted string
+                                  (see quoteCharacter) or is immediately
+                                  preceded by a literalCharacter.
+                                  Non-printable quote characters can be
+                                  provided as their hex values, and for tab
+                                  characters by its ASCII string "\t".
+                                  Processors should assume that the field
+                                  starts in the column following the previous
+                                  field if the previous field was fixed,
+                                  or in the column following the delimiter
+                                  from the previous field if the previous
+                                  field was delimited.
+                                  </doc:description>
+                                  <doc:example>,</doc:example>
+                                  <doc:example>\t</doc:example>
+                                  <doc:example>0x09</doc:example>
+                                  <doc:example>0x20</doc:example>
+                                </xs:appinfo>
+                              </xs:annotation>
+                            </xs:element>
+                            <xs:element name="collapseDelimiters" minOccurs="0">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>Treat consecutive delimiters
+                                  as one</doc:tooltip>
+                                  <doc:summary>Specification of how to
+                                  handle consecutive delimiters while
+                                  parsing</doc:summary>
+                                  <doc:description>
+                                  The collapseDelimiters element
+                                  specifies whether sequential delimiters
+                                  should be treated as a single delimiter or
+                                  multiple delimiters.    An example is when
+                                  a space delimiter is used; often there may
+                                  be several repeated spaces that should be
+                                  treated as a single delimiter, but not
+                                  always. The valid values are yes or no.
+                                  If it is set to yes, then consecutive
+                                  delimiters will be collapsed to one.  If set
+                                  to no or absent, then consecutive delimiters 
+                                  will be treated as separate delimiters. 
+                                  Default behaviour is no; hence, consecutive
+                                  delimiters will be treated as separate
+                                  delimiters, by default.
+                                  </doc:description>
+                                  <doc:example>yes</doc:example>
+                                  <doc:example>no</doc:example>
+                                </xs:appinfo>
+                              </xs:annotation>
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="yes"/>
+                                  <xs:enumeration value="no"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:element>
+                            <xs:element name="quoteCharacter" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>Quote character</doc:tooltip>
+                                  <doc:summary>Character used to quote values
+                                  for delimiter escaping</doc:summary>
+                                  <doc:description>This element specifies
+                                  a character to be used in the object for
+                                  quoting values so that field delimiters can
+                                  be used within the value. This basically
+                                  allows delimiter "escaping". The quoteChacter
+                                  is typically a " or '. When a processor
+                                  encounters a quote character, it should
+                                  not interpret any following characters as
+                                  a delimiter until a matching quote character
+                                  has been encountered (i.e., quotes come in
+                                  pairs). It is an error to not provide a
+                                  closing quote before the record ends.
+                                  Non-printable quote characters can be
+                                  provided as their hex values.
+                                  </doc:description>
+                                  <doc:example>"</doc:example>
+                                  <doc:example>'</doc:example>
+                                </xs:appinfo>
+                              </xs:annotation>
+                            </xs:element>
+                            <xs:element name="literalCharacter" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>Literal character</doc:tooltip>
+                                  <doc:summary>Character used to escape other
+                                  special characters</doc:summary>
+                                  <doc:description>This element specifies
+                                  a character to be used for escaping
+                                  special character values so that they
+                                  are treated as literal values.
+                                  This allows "escaping" for special
+                                  characters like quotes, commas, and spaces
+                                  when they are intended to be used in an
+                                  attribute value rather than being intended
+                                  as a delimiter.  The literalCharacter is
+                                  typically a \.</doc:description>
+                                  <doc:example>\</doc:example>
+                                </xs:appinfo>
+                              </xs:annotation>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="complex">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Complex text format
+                            </doc:tooltip>
+                            <doc:summary>A complex text format.
+                            </doc:summary>
+                            <doc:description>A complex text format that
+                            can describe delimited fields, fixed width
+                            fields, and mixtures of the two. This supports
+                            multiline records (where one record is distributed
+                            across multiple physical lines).  When using the
+                            complex format, the number of textFixed and
+                            textDelimited elements should exactly equal the
+                            number of attributes that have been described
+                            for the entity, and the order of the textFixed
+                            and textDelimited elements should correspond to
+                            the order of the attributes as described in the
+                            entity. Thus, for a delimited file with fourteen
+                            attributes, one should provide exactly fourteen
+                            textDelimited elements.
+                            </doc:description>
+                          </xs:appinfo>
+                        </xs:annotation>
+                        <xs:complexType>
+                          <xs:choice maxOccurs="unbounded">
+                            <xs:element name="textFixed">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>Fixed format text
+                                  </doc:tooltip>
+                                  <doc:summary>Describes the physical format
+                                  of data sequences that use a fixed
+                                  number of characters in a specified position
+                                  in the stream to locate attribute values.
+                                  </doc:summary>
+                                  <doc:description>Describes the physical
+                                  format of data sequences that use a fixed
+                                  number of characters in a specified position
+                                  in the stream to locate attribute values.
+                                  This method is common in sensor-derived
+                                  data and in legacy database systems.  To
+                                  parse it, one must know the number
+                                  of characters for each attribute and the
+                                  starting column and line to begin reading
+                                  the value.
+                                  </doc:description>
+                                </xs:appinfo>
+                              </xs:annotation>
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="fieldWidth" type="xs:unsignedLong">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Field width</doc:tooltip>
+                                        <doc:summary>Field width in
+                                        characters for fixed field
+                                        length.</doc:summary>
+                                        <doc:description>Fixed width fields
+                                        have a set length, thus the end of
+                                        the field can always be determined by
+                                        adding the fieldWidth to the starting
+                                        column number.</doc:description>
+                                        <doc:example>7</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                  <xs:element name="lineNumber" type="xs:unsignedLong" minOccurs="0">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Physical Line Number
+                                        </doc:tooltip>
+                                        <doc:summary>The line on which
+                                        the data field is found, when
+                                        the data record is written over
+                                        more than one physical line in
+                                        the file.</doc:summary>
+                                        <doc:description>A single logical
+                                        data record may be written over
+                                        several physical lines in a file,
+                                        with no special marker to indicate
+                                        the end of a record. In such
+                                        cases, the relative location of
+                                        a data field must be indicated
+                                        by both relative row and column
+                                        number.  The lineNumber should never
+                                        greater that the number of physical
+                                        lines per record.
+                                        </doc:description>
+                                        <doc:example>3</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                  <xs:element name="fieldStartColumn" type="xs:long" minOccurs="0">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Start column
+                                        </doc:tooltip>
+                                        <doc:summary>The starting
+                                        column number for a fixed format
+                                        attribute.</doc:summary>
+                                        <doc:description>Fixed width fields
+                                        have a set length, thus the end of
+                                        the field can always be determined by
+                                        adding the fieldWidth to the starting
+                                        column number. If the starting
+                                        column is not provided, processors
+                                        should assume that the field starts
+                                        in the column following the previous
+                                        field if the previous field was fixed,
+                                        or in the column following the
+                                        delimiter from the previous field if
+                                        the previous field was delimited.
+                                        </doc:description>
+                                        <doc:example>58</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                            <xs:element name="textDelimited">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>Delimited format text
+                                  </doc:tooltip>
+                                  <doc:summary>Describes the physical format
+                                  of data sequences that use delimiters
+                                  in the stream to locate attribute values.
+                                  </doc:summary>
+                                  <doc:description>Describes the physical
+                                  format of data sequences that use delimiters
+                                  in the stream to locate attribute values.
+                                  This method is common in data exported from
+                                  spreadsheets and database systems,
+                                  To parse it, one must know the character
+                                  that indicates the end of each attribute
+                                  and the line to begin reading the value.
+                                  </doc:description>
+                                </xs:appinfo>
+                              </xs:annotation>
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="fieldDelimiter" type="xs:string">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Field Delimiter character
+                                        </doc:tooltip>
+                                        <doc:summary>Character used
+                                        to delimit the end of a particular
+                                        attribute</doc:summary>
+                                        <doc:description>This element
+                                        specifies a character to be used
+                                        in the object for indicating the
+                                        ending column for an attribute.
+                                        The delimiter character itself is
+                                        not part of the attribute value,
+                                        but rather is present in the column
+                                        following the last character of the
+                                        value. Typical delimiter characters
+                                        include commas, tabs, spaces,
+                                        and semicolons.  The only time the
+                                        fieldDelimiter character is not
+                                        interpreted as a delimiter is if it
+                                        is contained in a quoted string (see
+                                        quoteCharacter) or is immediately
+                                        preceded by a literalCharacter.
+                                        Non-printable quote characters can
+                                        be provided as their hex values,
+                                        and for tab characters by its ASCII
+                                        string "\t".  Processors should
+                                        assume that the field starts in the
+                                        column following the previous field
+                                        if the previous field was fixed,
+                                        or in the column following the
+                                        delimiter from the previous field
+                                        if the previous field was delimited.
+                                        </doc:description>
+                                        <doc:example>,</doc:example>
+                                        <doc:example>\t</doc:example>
+                                        <doc:example>0x09</doc:example>
+                                        <doc:example>0x20</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                  <xs:element name="collapseDelimiters" minOccurs="0">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Treat consecutive
+                                        delimiters as single</doc:tooltip>
+                                        <doc:summary>Specification of how
+                                        to handle consecutive delimiters
+                                        while parsing </doc:summary>
+                                        <doc:description>
+                                        The collapseDelimiters element
+                                        specifies whether sequential delimiters
+                                        should be treated as a single delimiter
+                                        or multiple delimiters.    An example
+                                        is when a space delimiter is used;
+                                        often there may be several repeated
+                                        spaces that should be treated as a
+                                        single delimiter, but not always. The
+                                        valid values are yes or no.  If it
+                                        is set to yes, then consecutive
+                                        delimiters will be collapsed
+                                        to one.  If set to no or absent,
+                                        then consecutive delimiters will
+                                        be treated as separate delimiters.
+                                        Default behaviour is no; hence,
+                                        consecutive delimiters will be treated
+                                        as separate delimiters, by default.
+                                        </doc:description>
+                                        <doc:example>yes</doc:example>
+                                        <doc:example>no</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="yes"/>
+                                        <xs:enumeration value="no"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:element>
+                                  <xs:element name="lineNumber" type="xs:unsignedLong" minOccurs="0">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Physical Line Number
+                                        </doc:tooltip>
+                                        <doc:summary>The line on which
+                                        the data field is found, when
+                                        the data record is written over
+                                        more than one physical line in
+                                        the file.</doc:summary>
+                                        <doc:description>A single logical
+                                        data record may be written over
+                                        several physical lines in a file,
+                                        with no special marker to indicate
+                                        the end of a record. In such
+                                        cases, the relative location of
+                                        a data field must be indicated
+                                        by both relative row and column
+                                        number.
+                                        The lineNumber should never be
+                                        greater that the number of physical
+                                        lines per record.  When parsing the
+                                        first field on a physical line as
+                                        a delimited field, they should assume
+                                        that the field data starts in the
+                                        first column.  Otherwise, follow the
+                                        rules indicated under fieldDelimiter.
+                                        </doc:description>
+                                        <doc:example>3</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                  <xs:element name="quoteCharacter" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Quote character
+                                        </doc:tooltip>
+                                        <doc:summary>Character used
+                                        to quote values for delimiter
+                                        escaping</doc:summary>
+                                        <doc:description>This element
+                                        specifies a character to be used in
+                                        the object for quoting values so
+                                        that field delimiters can be used
+                                        within the value. This basically
+                                        allows delimiter "escaping". The
+                                        quoteChacter is typically a " or
+                                        '. When a processor encounters
+                                        a quote character, it should not
+                                        interpret any following characters
+                                        as a delimiter until a matching
+                                        quote character has been encountered
+                                        (i.e., quotes come in pairs). It is
+                                        an error to not provide a closing
+                                        quote before the record ends.
+                                        Non-printable quote characters
+                                        can be provided as their hex
+                                        values.</doc:description>
+                                        <doc:example>"</doc:example>
+                                        <doc:example>'</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                  <xs:element name="literalCharacter" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:annotation>
+                                      <xs:appinfo>
+                                        <doc:tooltip>Literal character
+                                        </doc:tooltip>
+                                        <doc:summary>Character used
+                                        to escape other special
+                                        characters</doc:summary>
+                                        <doc:description>This element
+                                        specifies a character to be used
+                                        for escaping special character
+                                        values so that they are treated
+                                        as literal values.  This allows
+                                        "escaping" for special characters
+                                        like quotes, commas, and spaces
+                                        when they are intended to be used
+                                        in an attribute value rather than
+                                        being intended as a delimiter.
+                                        The literalCharacter is typically
+                                        a \.</doc:description>
+                                        <doc:example>\</doc:example>
+                                      </xs:appinfo>
+                                    </xs:annotation>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:choice>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="externallyDefinedFormat">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Externally Defined Format</doc:tooltip>
+                    <doc:summary>Information about a non-text or proprietary
+                    formatted object.
+                    </doc:summary>
+                    <doc:description>Information about a non-text or
+                    proprietary formatted object.
+                    The description names the format explicitly, but assumes
+                    a processor implicitly knows how to parse that format
+                    to extract the data.  A format version can be included.
+                    This is mainly used for proprietary formats, including
+                    binary files like Microsoft Excel and text formats like
+                    ESRI's ArcInfo export format.  This is not a recommended
+                    way to permanently archive data because the software to
+                    parse the format is unlikely to be available over extended
+                    periods, but is included to allow for commonly used
+                    physical formats.
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="formatName" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Format Name</doc:tooltip>
+                          <doc:summary>Name of the format of the data
+                          object</doc:summary>
+                          <doc:description>Name of the format of
+                          the data object</doc:description>
+                          <doc:example>Microsoft Excel</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="formatVersion" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Format Version</doc:tooltip>
+                          <doc:summary>Version of the format of the
+                    data object</doc:summary>
+                          <doc:description>Version of the format of
+                          the data object</doc:description>
+                          <doc:example>2000 (9.0.2720)</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="citation" type="cit:CitationType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Format citation</doc:tooltip>
+                          <doc:summary>Citation providing more details about
+                          the physical format.
+                          </doc:summary>
+                          <doc:description>Citation providing more detail about
+                          the physical format, including parsing information
+                          or information about the software required for
+                          reading the object.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="binaryRasterFormat">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Raster image format</doc:tooltip>
+                    <doc:summary>Contains binary raster data header
+                    parameters</doc:summary>
+                    <doc:description>The binaryRasterInfo element is a
+                    container for various parameters used to described the
+                    contents of binary raster image files. In this case, it is
+                    based on a white paper on the ESRI site that describes the
+                    header information used for BIP and BIL files ("Extendable
+                    Image Formats for ArcView GIS 3.1 and
+                    3.2").</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="rowColumnOrientation">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Orientation for reading rows and columns
+                          </doc:tooltip>
+                          <doc:summary>Orientation for reading rows and columns.
+                          </doc:summary>
+                          <doc:description> Specifies whether the data should
+                          be read across rows or down columns.  The valid
+                          values are column or row.  If set to 'column', then
+                          the data are read down columns. If set to 'row',
+                          then the data are read across rows.</doc:description>
+                          <doc:example>column</doc:example>
+                          <doc:example>row</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="column"/>
+                          <xs:enumeration value="row"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="multiBand" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Multiple band image</doc:tooltip>
+                          <doc:summary>Multiple band image information.
+                          </doc:summary>
+                          <doc:description>Information needed to properly
+                          interpret a multiband image.
+                          </doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="nbands" type="xs:int">
+                            <xs:annotation>
+                              <xs:appinfo>
+                                <doc:tooltip>Number of Bands</doc:tooltip>
+                                <doc:summary>The number of spectral bands in the
+                                image.</doc:summary>
+                                <doc:description>The number of spectral
+                                bands in the image. Must be greater than 1.
+                                </doc:description>
+                                <doc:example>2</doc:example>
+                              </xs:appinfo>
+                            </xs:annotation>
+                          </xs:element>
+                          <xs:element name="layout" type="res:NonEmptyStringType">
+                            <xs:annotation>
+                              <xs:appinfo>
+                                <doc:tooltip>Layout</doc:tooltip>
+                                <doc:summary>The organization of the bands
+                                in the image file.</doc:summary>
+                                <doc:description>The organization of
+                                the bands in the image file. Acceptable
+                                values are bil - Band interleaved by
+                                line. bip - Band interleaved by pixel.
+                                bsq - Band sequential.
+                                </doc:description>
+                                <doc:example>bil</doc:example>
+                                <doc:example>bip</doc:example>
+                                <doc:example>bsq</doc:example>
+                              </xs:appinfo>
+                            </xs:annotation>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="nbits" type="xs:int">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Number of Bits</doc:tooltip>
+                          <doc:summary>The number of bits per pixel per
+                          band.</doc:summary>
+                          <doc:description>The number of bits per pixel per
+                          band. Acceptable values are typically 1, 4, 8, 16,
+                          and 32. The default value is eight bits per pixel per
+                          band. For a true color image with three bands (R, G,
+                          B) stored using eight bits for each pixel in each
+                          band, nbits equals eight and nbands equals three,
+                          for a total of twenty-four bits per pixel.
+                          </doc:description>
+                          <doc:example>8</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="byteorder" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Byte Order</doc:tooltip>
+                          <doc:summary>The byte order in which values are
+                          stored.</doc:summary>
+                          <doc:description>The byte order in which
+                          values are stored. The byte order is important for
+                          sixteen-bit and higher images, that have two or more
+                          bytes per pixel.
+                          Acceptable values are little-endian (common on Intel
+                          systems like PCs) and big-endian (common on
+                          Motorola platforms).</doc:description>
+                          <doc:example>little-endian</doc:example>
+                          <doc:example>big-endian</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="skipbytes" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Skip Bytes</doc:tooltip>
+                          <doc:summary>The number of bytes of data in the
+                          image file to skip in order to reach the start of the
+                          image data.</doc:summary>
+                          <doc:description>The number of bytes of data in the
+                          image file to skip in order to reach the start of the
+                          image data. This keyword allows you to bypass any
+                          existing image header information in the file. The
+                          default value is zero bytes.</doc:description>
+                          <doc:example>0</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="bandrowbytes" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Bytes per band per row</doc:tooltip>
+                          <doc:summary>The number of bytes per band per
+                          row.</doc:summary>
+                          <doc:description>The number of bytes per band per
+                          row. This must be an integer. This keyword is used
+                          only with BIL files when there are extra bits at the
+                          end of each band within a row that must be
+                          skipped.</doc:description>
+                          <doc:example>3</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="totalrowbytes" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Total bytes of data per row</doc:tooltip>
+                          <doc:summary>The total number of bytes of data
+                          per row.</doc:summary>
+                          <doc:description>The total number of bytes of data
+                          per row. Use totalrowbytes when there are extra
+                          trailing bits at the end of each
+                          row.</doc:description>
+                          <doc:example>8</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="bandgapbytes" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Bytes between bands</doc:tooltip>
+                          <doc:summary>The number of bytes between bands in
+                          a BSQ format image.</doc:summary>
+                          <doc:description>The number of bytes between bands in
+                          a BSQ format image. The default is
+                          zero.</doc:description>
+                          <doc:example>1</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="distribution" type="PhysicalDistributionType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Distribution Information</doc:tooltip>
+              <doc:summary>Information on how the resource is distributed
+              online and offline</doc:summary>
+              <doc:description>This element provides information on how the
+              resource is distributed. Connections to online
+              systems can be described as URLs or as a list of connection parameters.
+               Please see the Type definition for complete information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <!-- 
+
+physical distribution type built from resource, access and local components 
+-->
+  <xs:complexType name="PhysicalDistributionType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>PhysicalDistributionType</doc:tooltip>
+        <doc:summary>PhysicalDistributionType</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>The PhysicalDistributionType contains the information required
+            for retrieving the resource.
+             </para>
+            <para>
+             It differs from the 
+             <ulink url="eml-resource.html#DistributionType">
+                <citetitle>res:DistributionType</citetitle>
+              </ulink>:
+              </para>
+            <itemizedlist>
+              <listitem>
+                <para>Generally, the PhysicalDisribtutionType is intended for download
+              whereas the Type at the resource level is intended primarily
+              for information.</para>
+              </listitem>
+              <listitem>
+                <para>The phys:PhysicalDistributionType includes an optional access tree
+              which can be used to override access rules applied at the resource
+              level. Access for the documents included entities can then be managed
+              individually.</para>
+              </listitem>
+              <listitem>
+                <para>Also see individual sub elements for more information.</para>
+              </listitem>
+            </itemizedlist>
+          </section>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element name="online" type="PhysicalOnlineType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>online</doc:tooltip>
+                <doc:summary>online</doc:summary>
+                <doc:description>Information for a resource that is distributed online.
+              Please see the Type definition for complete information.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="offline" type="res:OfflineType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>offline</doc:tooltip>
+                <doc:summary>offline</doc:summary>
+                <doc:description>Information for a resource that is distributed offline.
+              Please see the Type definition for complete information.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="inline" type="res:InlineType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>inline</doc:tooltip>
+                <doc:summary>inline</doc:summary>
+                <doc:description>Information for a resource that is distributed inline, i.e., along
+              with the metadata.
+              Please see the Type definition for complete information.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="access" type="acc:AccessType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>access</doc:tooltip>
+              <doc:summary>access</doc:summary>
+              <doc:description>When this element occurs in a distribution module,
+              it controls access only to the resource being described by the same
+              distribution parent. 
+              Please see the Type definition for complete information on constructing
+              an access tree.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <!--
+
+phys:online type -->
+  <xs:complexType name="PhysicalOnlineType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>PhysicalOnlineType</doc:tooltip>
+        <doc:summary>PhysicalOnlineType</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>Distribution information for accessing the resource online, 
+            represented either as a URL or as the series of named parameters 
+            needed to connect. The URL field can contain a simple web address 
+            or an entire query string. The connection element allows the components 
+            of a complex protocol to be described individually.   </para>
+            <para>The PhysicalOnlineType differs from the
+            <ulink url="eml-resource.html#OnlineType">
+                <citetitle>res:OnlineType </citetitle>
+              </ulink>
+          in that this type only allows a connectionDefinition 
+             to appear as the child of a connection. In other words, in a 
+             PhysicalOnlineType, the connectionDefinition cannot be abstracted, and
+             must be included as part of an actual connection.
+             </para>
+          </section>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="onlineDescription" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>onlineDescription</doc:tooltip>
+            <doc:summary>onlineDescription</doc:summary>
+            <doc:description>The onlineDescription element can hold a brief description of the content of the online element's online|offline|inline child. This description element could supply content for an html anchor tag.  
+              </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice>
+        <xs:element name="url" type="res:UrlType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>url</doc:tooltip>
+              <doc:summary>url</doc:summary>
+              <doc:description>The URL of the resource that is available online. 
+              Please see the Type definition for complete information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="connection" type="res:ConnectionType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>connection</doc:tooltip>
+              <doc:summary>connection</doc:summary>
+              <doc:description>A connection to a resource that is available online.  
+              Please see the Type definition for complete information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-project.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-project.xsd
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+    xmlns:txt="eml://ecoinformatics.org/text-2.1.1" 
+    xmlns:prot="eml://ecoinformatics.org/protocol-2.1.1" 
+    xmlns:rp="eml://ecoinformatics.org/party-2.1.1" 
+    xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" 
+    xmlns:cit="eml://ecoinformatics.org/literature-2.1.1" 
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+    xmlns="eml://ecoinformatics.org/project-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/project-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+  schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/party-2.1.1" 
+  schemaLocation="eml-party.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" 
+  schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/literature-2.1.1" 
+  schemaLocation="eml-literature.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/text-2.1.1" 
+  schemaLocation="eml-text.xsd"/>
+  <xs:annotation>
+    <xs:documentation>'$RCSfile: eml-project.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.83 $'
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-project</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>The eml-project module - Research context information for
+            resources</title>
+            <para>The eml-project module describes the research context in
+            which the dataset was created, including descriptions of over-all
+            motivations and goals, funding, personnel, description of the study
+            area etc. This is also the module to describe the design of the
+            project: the scientific questions being asked, the architecture of
+            the design, etc. This module is used to place the dataset that is
+            being documented into its larger research context.</para>
+            <para>The eml-project module, like other modules, may be
+            "referenced" via the &lt;references&gt; tag. This allows a research
+            project to be described once, and then used as a reference in other
+            locations within the EML document via its ID.</para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>Use eml-project to document the research context
+        of any dataset or project.</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="researchProject" type="ResearchProjectType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>research project</doc:tooltip>
+        <doc:summary>The root element of this module.</doc:summary>
+        <doc:description>The root element of this module. This is used for
+        testing or if you want to instantiate a stand-alone project
+        file.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="ResearchProjectType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Research project descriptor</doc:tooltip>
+        <doc:summary>Descriptor of a research context for a dataset or another
+        project.</doc:summary>
+        <doc:description>The researchProject complex type describes the
+        structure for documenting the research context of a dataset or another
+        project. It can include research goals, motivations, theory,
+        hypotheses, etc., as well as a description of research efforts that
+        form the basis for other work. (To document methods specific to a
+        dataset use eml-methods.) This field can be associated with a dataset
+        using the project field of eml-dataset, and can be associated with
+        another project using the relatedProject field of eml-project (this
+        module).</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="title" type="res:NonEmptyStringType" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Project Title</doc:tooltip>
+              <doc:summary>Title of the project.</doc:summary>
+              <doc:description>A descriptive title for the research
+              project.</doc:description>
+              <doc:example>Species diversity in Tennessee riparian
+              habitats.</doc:example>
+              
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="personnel" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Personnel</doc:tooltip>
+              <doc:summary>Contact and role information for people involved in
+              the research project.</doc:summary>
+              <doc:description>The Personnel field extends ResponsibleParty
+              with role information and is used to document people involved in
+              a research project by providing contact information and their
+              role in the project. A project must have at least one
+              originator.</doc:description>
+              
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="rp:ResponsibleParty">
+                <xs:sequence maxOccurs="unbounded">
+                  <xs:element name="role" type="rp:RoleType">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Role</doc:tooltip>
+                        <doc:summary>Role information for people involved in
+                        the research project.</doc:summary>
+                        <doc:description>The role field contains information
+                        about role a person plays in a research project. There
+                        are a number of suggested roles, however, it is
+                        possible to add a role if the suggested roles are not
+                        adequate.</doc:description>
+                        <doc:example>author</doc:example>
+                        <doc:example>contentProvider</doc:example>
+                        <doc:example>custodianSteward</doc:example>
+                        <doc:example>distributor</doc:example>
+                        <doc:example>editor</doc:example>
+                        <doc:example>metadataProvider</doc:example>
+                        <doc:example>originator</doc:example>
+                        <doc:example>owner</doc:example>
+                        <doc:example>pointOfContact</doc:example>
+                        <doc:example>principalInvestigator</doc:example>
+                        <doc:example>processor</doc:example>
+                        <doc:example>publisher</doc:example>
+                        <doc:example>user</doc:example>
+                        <doc:example>fieldStationManager</doc:example>
+                        <doc:example>informationManager</doc:example>
+                        
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="abstract" type="txt:TextType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Abstract</doc:tooltip>
+              <doc:summary>Project Abstract.</doc:summary>
+              <doc:description>Descriptive abstract that summarizes information
+              about the research project.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="funding" type="txt:TextType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Funding</doc:tooltip>
+              <doc:summary>Funding information.</doc:summary>
+              <doc:description>The funding field is used to provide information
+              about funding sources for the project such as: grant and contract
+              numbers; names and addresses of funding sources. Other
+              funding-related information may also be
+              included.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="studyAreaDescription" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Description of the study area.</doc:tooltip>
+              <doc:summary>Description of the physical area associated with the
+              research project, potentially including coverage, climate,
+              geology, disturbances, etc.</doc:summary>
+              <doc:description>The studyAreaDescription field documents the
+              physical area associated with the research project. It can
+              include descriptions of the geographic, temporal, and taxonomic
+              coverage of the research location and descriptions of domains
+              (themes) of interest such as climate, geology, soils or
+              disturbances or reference to citable biological or geophysical
+              classification systems such as the Bailey Ecoregions or the
+              Holdridge Life Zones.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element name="descriptor">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Non-coverage characteristics of the study
+                    area</doc:tooltip>
+                    <doc:summary>Description of non-coverage characteristics of
+                    the study area such as climate, geology,
+                    disturbances</doc:summary>
+                    <doc:description>The descriptor field is used to document
+                    domains (themes) of interest such as climate, geology,
+                    soils or disturbances or references to citable biological
+                    or geophysical classification systems such as the Bailey
+                    Ecoregions or the Holdridge Life Zones.</doc:description>
+                    
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence maxOccurs="unbounded">
+                    <xs:element name="descriptorValue" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Description of some aspect of the study
+                          area.</doc:tooltip>
+                          <doc:summary>Description of some aspect of the study
+                          area.</doc:summary>
+                          <doc:description>The descriptorValue field contains
+                          the value of a descriptor, describing some aspect of
+                          the study area. This may either be a general
+                          description in textual form or the value part of a
+                          "name/value" pair where the name is entered in the
+                          attribute "name_or_id". For example, if the value of
+                          the "name" attribute" of the element "descriptor" is
+                          "climate", and the value of the attribute
+                          "name_or_id" of the element "descriptorValue" is
+                          "Annual Precipitation" then the value of this element
+                          could be "12.5 inches".</doc:description>
+                          <doc:example>12.5 inches</doc:example>
+                          <doc:example>tundra-forest</doc:example>
+                          
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="name_or_id" type="xs:string" use="optional">
+                              <xs:annotation>
+                                <xs:appinfo>
+                                  <doc:tooltip>The name or ID of a descriptor
+                                  value.</doc:tooltip>
+                                  <doc:summary>The name part of a name/value
+                                  pair of a descriptor; or ID portion of a
+                                  classification, if applicable.</doc:summary>
+                                  <doc:description>The name_or_id field is the
+                                  name part of a name/value pair of a
+                                  descriptor; or ID portion of a
+                                  classification, if applicable. The values of
+                                  biogeophysical classification systems, e.g.
+                                  Bailey-Ecoregions, often take the form of an
+                                  ID or Code along with a text representation.
+                                  For example, the ID/Code M131 refers to the
+                                  phrase "Open Woodland -Tundra". M131 is an
+                                  unambiguous reference to a more detailed
+                                  description. If one is using a published
+                                  classification system then there should be a
+                                  corresponding citation to the source, e.g.,
+                                  Bailey,R.G., 1996 "Ecosystem
+                                  Geography".</doc:description>
+                                  <doc:example>M131</doc:example>
+                                  <doc:example>Average Annual
+                                  Rainfall</doc:example>
+                                  
+                                </xs:appinfo>
+                              </xs:annotation>
+                            </xs:attribute>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="citation" type="cit:CitationType" minOccurs="0" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>citation</doc:tooltip>
+                          <doc:summary>A citation for this
+                          descriptor.</doc:summary>
+                          <doc:description>A citation for this
+                          descriptor.</doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="DescriptorType" use="required">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>name</doc:tooltip>
+                        <doc:summary>The name of the descriptor
+                        system.</doc:summary>
+                        <doc:description>The name of the descriptor system. The
+                        name can be either a theme such as climate or
+                        hydrology, or the name of a citable classification
+                        system.</doc:description>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="citableClassificationSystem" type="xs:boolean" use="required">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>citation classification
+                        system</doc:tooltip>
+                        <doc:summary>This boolean attribute defines whether
+                        this descriptor comes from a citable classification
+                        system or not.</doc:summary>
+                        <doc:description>This boolean attribute defines whether
+                        this descriptor comes from a citable classification
+                        system or not.</doc:description>
+                      </xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="citation" type="cit:CitationType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>citation</doc:tooltip>
+                    <doc:summary>The citation for this
+                    descriptor.</doc:summary>
+                    <doc:description>The citation for this
+                    descriptor.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="coverage" type="cov:Coverage" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>coverage</doc:tooltip>
+                    <doc:summary>The coverage of this descriptor.</doc:summary>
+                    <doc:description>The coverage of this
+                    descriptor.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="designDescription" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Description of research design</doc:tooltip>
+              <doc:summary>Description of the design of the research
+              project</doc:summary>
+              <doc:description>The field designDescription contains general
+              textual descriptions of research design. It can include detailed
+              accounts of goals, motivations, theory, hypotheses, strategy,
+              statistical design, and actual work. Literature citations may
+              also be used to describe the research design.</doc:description>
+              
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element name="description" type="txt:TextType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Description of research design</doc:tooltip>
+                    <doc:summary>Textual description of research
+                    design.</doc:summary>
+                    <doc:description>The field designDescription contains
+                    general textual descriptions of research design. It can
+                    include detailed accounts of goals, motivations, theory,
+                    hypotheses, strategy, statistical design, and actual
+                    work.</doc:description>
+                    
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="citation" type="cit:CitationType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Citation for research design</doc:tooltip>
+                    <doc:summary>Citation that describes the research
+                    design.</doc:summary>
+                    <doc:description>The citation field is a citation to
+                    literature that describes elements of the research design,
+                    such as goals, motivations, theory, hypotheses, strategy,
+                    statistical design, and actual work.</doc:description>
+                    
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="relatedProject" type="ResearchProjectType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>related project</doc:tooltip>
+              <doc:summary>This field is a recursive link to another
+              project.</doc:summary>
+              <doc:description>This field is a recursive link to another
+              project. This allows projects to be nested under one another for
+              the case where one project spawns another.</doc:description>
+              
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:simpleType name="DescriptorType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Descriptor Theme Type</doc:tooltip>
+        <doc:summary>The type of descriptor theme or the name of a
+        classification system.</doc:summary>
+        <doc:description>The DescriptorType is used to represent either the
+        name of a citable classification system/controlled vocabulary such as
+        the Bailey classification of ecoregions or a domain of physical
+        descriptors such as climate or disturbances.</doc:description>
+        <doc:example>climate</doc:example>
+        <doc:example>soils</doc:example>
+        <doc:example>hydrology</doc:example>
+        <doc:example>"bailey"</doc:example>
+        <doc:example>biome</doc:example>
+        <doc:example>disturbance</doc:example>
+        <doc:example>geology</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="climate"/>
+          <xs:enumeration value="hydrology"/>
+          <xs:enumeration value="soils"/>
+          <xs:enumeration value="geology"/>
+          <xs:enumeration value="disturbance"/>
+          <xs:enumeration value="bailey"/>
+          <xs:enumeration value="biome"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string"/>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-protocol.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-protocol.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="eml://ecoinformatics.org/protocol-2.1.1" xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:md="eml://ecoinformatics.org/methods-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:acc="eml://ecoinformatics.org/access-2.1.1" targetNamespace="eml://ecoinformatics.org/protocol-2.1.1" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/methods-2.1.1" schemaLocation="eml-methods.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/access-2.1.1" schemaLocation="eml-access.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+    '$RCSfile: eml-protocol.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2008-09-26 23:59:46 $'
+      '$Revision: 1.60 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-protocol</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-protocol module - Research protocol specific information
+            </title>
+            <para>
+              The EML Protocol Module is used to define
+              abstract, prescriptive procedures for generating or processing
+              data.  Conceptually, a protocol is a standardized method.
+            </para>
+            <para>
+              Eml-protocol resembles eml-methods; however, eml-methods is
+              descriptive (often
+              written in the declarative mood:  "I took five subsamples...")
+              whereas eml-protocol is prescriptive (often written in the
+              imperative mood:  "Take five subsamples...").  A protocol
+              may have versions, whereas methods (as used in eml-methods)
+              should not.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>Use eml-protocol to describe prescriptive
+        procedures that can be associated with other descriptive or
+        prescriptive procedures.</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:complexType name="ProtocolType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>A prescriptive procedure; a standardized method
+        </doc:tooltip>
+        <doc:summary>A reusable container for information related to
+        a prescriptive procedure.</doc:summary>
+        <doc:description>The ProtocolType container defines a number of
+        reusable fields that can be referenced from multiple EML
+        modules.  It represents well-defined, prescriptive procedures
+        that can be used to document other prescriptive procedures or
+        descriptive procedures such as methods.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="res:ResourceGroup"/>
+        <xs:element name="proceduralStep" type="md:ProcedureStepType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:element name="protocol" type="ProtocolType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>A prescriptive procedure</doc:tooltip>
+        <doc:summary>A reusable container for information related to
+        a prescriptive procedure.</doc:summary>
+        <doc:description>The protocol field provides a container for other
+        related fields, such as proceduralStep and ResourceGroup.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-resource.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-resource.xsd
@@ -1,0 +1,1220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:txt="eml://ecoinformatics.org/text-2.1.1" xmlns:rp="eml://ecoinformatics.org/party-2.1.1" xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" xmlns="eml://ecoinformatics.org/resource-2.1.1" targetNamespace="eml://ecoinformatics.org/resource-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/party-2.1.1" schemaLocation="eml-party.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/text-2.1.1" schemaLocation="eml-text.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+  
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-resource.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.93 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-resource</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-resource module - Base information for
+              all resources
+            </title>
+            <para>
+              The eml-resource module contains general information that
+              describes dataset resources, literature resources, protocol
+              resources, and software resources. Each of the above four types of
+              resources share a common set of information, but also have
+              information that is unique to that particular resource type.  Each
+              resource type uses the eml-resource module to document the
+              information common to all resources, but then extend
+              eml-resource with modules that are specific to that particular
+              resource type.  For instance, all resources have creators,
+              titles, and perhaps keywords, but only the dataset resource would
+              have a "data table" within it.  Likewise, a literature
+              resource may have an "ISBN" number associated with it,
+              whereas the other resource types would not.
+            </para>
+            <para>
+              The eml-resource module is exclusively used by other modules, and is
+              therefore not a stand-alone module.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all datasets</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:group name="ResourceGroup">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Resource Base</doc:tooltip>
+        <doc:summary>Generic information about any resource that is being
+        described.</doc:summary>
+        <doc:description>The 'ResourceBase' complexType contains information
+        that is inherited by each resource type that is being documented. The
+        sub-elements with the resource base are common to all
+        resources.</doc:description>
+        <doc:example>Please see the individual sub-fields for specific
+        examples.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alternateIdentifier" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Alternate Identifier</doc:tooltip>
+            <doc:summary>A secondary identifier for this entity</doc:summary>
+            <doc:description>An additional, secondary identifier for this
+            entity. The primary identifier belongs in the "id" attribute, but
+            additional identifiers that are used to label this entity, possibly
+            from different data management systems, can be listed
+            here.</doc:description>
+            <doc:example>VCR3465</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="system" type="SystemType" use="optional"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="shortName" type="NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Short Name</doc:tooltip>
+            <doc:summary>A short name that describes the resource, sometimes a
+            filename.</doc:summary>
+            <doc:description>The 'shortName' field provides a concise name that
+            describes the resource that is being documented. It is the
+            appropriate place to store a filename associated with other storage
+            systems.</doc:description>
+            <doc:example>vernal-data-1999</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="title" type="i18nNonEmptyStringType" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Title</doc:tooltip>
+            <doc:summary>A brief description of the resource, providing enough
+            detail to differentiate it from other similar
+            resources.</doc:summary>
+            <doc:description>The 'title' field provides a description of the
+            resource that is being documented that is long enough to
+            differentiate it from other similar resources. Multiple titles may
+            be provided, particularly when trying to express the title in more
+            than one language (use the "xml:lang" attribute to indicate the
+            language if not English/en).</doc:description>
+            <doc:example>Vernal pool amphibian density data, Isla Vista,
+            1990-1996.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="creator" type="rp:ResponsibleParty" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Creator</doc:tooltip>
+            <doc:summary>The people or organizations who created this
+            resource.</doc:summary>
+            <doc:description>The 'creator' element provides the full name of
+            the person, organization, or position who created the resource. The
+            list of creators for a resource represent the people and
+            organizations who should be cited for the
+            resource.</doc:description>
+            <doc:example>For a book, the creators are its
+            authors.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="metadataProvider" type="rp:ResponsibleParty" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Metadata Provider</doc:tooltip>
+            <doc:summary>The people or organizations who created provided
+            documentation and other metadata for this resource.</doc:summary>
+            <doc:description>The 'metadataProvider' element provides the full
+            name of the person, organization, or position who created
+            documentation for the resource.</doc:description>
+            <doc:example>The scientist who collected the data, sometimes a data
+            technician, or other individual.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="associatedParty" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Associated Party</doc:tooltip>
+            <doc:summary>Other people or organizations who should be associated
+            with this resource.</doc:summary>
+            <doc:description>The 'associatedParty' element provides the full
+            name of other people, organizations, or positions who should be
+            associated with the resource. These parties might play various
+            roles in the creation or maintenance of the resource, and these
+            roles should be indicated in the "role" element.</doc:description>
+            <doc:example>The technician who collected the data.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="rp:ResponsibleParty">
+              <xs:sequence>
+                <xs:element name="role" type="rp:RoleType">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Role</doc:tooltip>
+                      <doc:summary>The role the party played with respect to
+                      the resource.</doc:summary>
+                      <doc:description>Use this field to describe the role the
+                      party played with respect to the resource. Some potential
+                      roles include technician, reviewer, principal
+                      investigator, and many others.</doc:description>
+                      <doc:example>principalInvestigator</doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:element>
+              </xs:sequence>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="pubDate" type="yearDate" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Publication date</doc:tooltip>
+            <doc:summary>The publication date of the resource.</doc:summary>
+            <doc:description>The 'pubDate' field represents the date that the
+            resource was published. The format should be represented as: CCYY,
+            which represents a 4 digit year, or as CCYY-MM-DD, which denotes
+            the full year, month, and day. Note that month and day are optional
+            components. Formats must conform to ISO 8601.</doc:description>
+            <doc:example>1999-10-26</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="language" type="i18nNonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Language</doc:tooltip>
+            <doc:summary>The language in which the resource is
+            written.</doc:summary>
+            <doc:description>The language in which the resource is written.
+            This can be a well-known language name, or one of the ISO language
+            codes to be more precise.</doc:description>
+            <doc:example>English</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="series" type="NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Series</doc:tooltip>
+            <doc:summary>The series from which the resource came.</doc:summary>
+            <doc:description>This field describes the series of resources that
+            include the resource being described. For example, a volume of a
+            journal may be part of a series of the journal for a particular
+            year.</doc:description>
+            <doc:example>Volume 20</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="abstract" type="txt:TextType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Abstract</doc:tooltip>
+            <doc:summary>A brief overview of the resource.</doc:summary>
+            <doc:description>A brief overview of the resource that is being
+            documented. The abstract should include basic information that
+            summarizes the resource.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="keywordSet" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Keyword information</doc:tooltip>
+            <doc:summary>Keyword information that describes the
+            resource.</doc:summary>
+            <doc:description>The 'keywordSet' element is a container for the
+            'keyword' and 'keywordThesaurus' fields. Each keywordSet field can
+            contain one or more keywords and a name of a thesaurus for the set
+            of keywords. Each keyword field should contain one and only one
+            keyword (i.e., keywords should not be separated by commas or other
+            delimiters).</doc:description>
+            <doc:example>Please see the examples for the subfields contained
+            within this field.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="keyword" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Keyword</doc:tooltip>
+                  <doc:summary>A single keyword that describes the
+                  resource.</doc:summary>
+                  <doc:description>This field names a keyword or key phrase that
+                  concisely describes the resource or is related to the
+                  resource. Each keyword field should contain one and only one
+                  keyword (i.e., keywords should not be separated by commas or
+                  other delimiters).</doc:description>
+                  <doc:example>biodiversity</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType mixed="true">
+                <xs:complexContent>
+                  <xs:extension base="i18nNonEmptyStringType">
+                    <xs:attribute name="keywordType" type="KeyTypeCode" use="optional">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Keyword type</doc:tooltip>
+                          <doc:summary>The type of each keyword.</doc:summary>
+                          <doc:description>This field classifies the keyword
+                          that has been provided from a list of pre-determined
+                          categories. The possible types are listed in the
+                          example.</doc:description>
+                          <doc:example>
+                          "place","stratum","temporal","theme",
+                          or "taxonomic"</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:complexContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="keywordThesaurus" type="NonEmptyStringType" minOccurs="0">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Keyword thesaurus</doc:tooltip>
+                  <doc:summary>The name of a thesaurus from which the keyword
+                  is derived.</doc:summary>
+                  <doc:description>This field provides the name of the official
+                  keyword thesaurus from which keyword was derived. The keyword
+                  thesauri are usually discipline specific.</doc:description>
+                  <doc:example>IRIS keyword thesaurus</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="additionalInfo" type="txt:TextType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Additional Information</doc:tooltip>
+            <doc:summary>Any extra information pertitent to the
+            resource.</doc:summary>
+            <doc:description>This field provides any information that is not
+            characterized by the other resource metadata
+            fields.</doc:description>
+            <doc:example>Copyright 2001, Robert Warner</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="intellectualRights" type="txt:TextType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Intellectual Property Rights</doc:tooltip>
+            <doc:summary>Intellectual property rights regarding usage and
+            licensing of this resource.</doc:summary>
+            <doc:description>Typically, an intellectual Rights element will
+            contain a rights management statement for the resource, or
+            reference a service providing such information. Rights information
+            encompasses Intellectual Property Rights (IPR), Copyright, and
+            various Property Rights. In the case of a data set, rights might
+            include requirements for use, requirements for attribution, or other
+            requirements the owner would like to impose.</doc:description>
+            <doc:example>Copyright 2001 Regents of the University of California
+            Santa Barbara. Free for use by all individuals provided that the
+            owners are acknowledged in any use or publication.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="distribution" type="DistributionType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Distribution Information</doc:tooltip>
+            <doc:summary>Information on how the resource is distributed online
+            and offline</doc:summary>
+            <doc:description>This element provides information on how the
+            resource is distributed. When used at the resource level, this element can provide
+             only general information, but elements for describing connections to online
+            systems are provided. See the Type for specific recommendations and examples.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="coverage" type="cov:Coverage" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Resource coverage</doc:tooltip>
+            <doc:summary>Extent of the coverage of the resource.</doc:summary>
+            <doc:description>This element describes the extent of the coverage
+            of the resource in terms of its spatial extent, temporal extent,
+            and taxonomic extent. For data sets, this is useful to specify the
+            entire extent to which all of the data might
+            apply.</doc:description>
+            <doc:example>See the coverage module for examples.</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="ReferencesGroup">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>References Group</doc:tooltip>
+        <doc:summary>A group of elements repeatedly used throughout EML
+        to reference IDs.</doc:summary>
+        <doc:description>A group containing the "references" element that
+        is used throughout EML.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="references">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>References</doc:tooltip>
+            <doc:summary>The id of another element in this
+            EML document to be used to here in this context.
+            </doc:summary>
+            <doc:description>The id of another element in
+            this EML document to be used to here in this context.
+            This is used instead of duplicating information when an identical
+            piece of information needs to be used multiple times in an
+            EML document. For example, if the same person is the creator,
+            metadataProvider, and contact for a dataset, their name and address
+            can be provided once as part of the "creator" element, and then
+            their "id" can be used in the "references" element of 
+            metadataProvider and contact.  This reduces the likelihood of
+            error by reducing redundancy, and allows one to specify that
+            two pieces of information are identical.  To be a valid EML
+            document, the content of every "references" element MUST be
+            defined in the document as the value of an "id" attribute on
+            some element within the document.  Other critical rules
+            about the use of IDs and references in EML are provided in the
+            text of the EML specification.</doc:description>
+            <doc:example>knb.45.3</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="system" type="SystemType" use="optional" default="document"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="KeyTypeCode">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Keyword type codes</doc:tooltip>
+        <doc:summary>The list of keyword categories</doc:summary>
+        <doc:description>This field provides a restricted list of categories
+        that a keyword may fall under.</doc:description>
+        <doc:example>place</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="place">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Place Keywords</doc:tooltip>
+            <doc:summary>Keywords pertaining to a spatial location</doc:summary>
+            <doc:description>Keywords naming geographic locations associated 
+            with the data set.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="stratum">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Stratum Keywords</doc:tooltip>
+            <doc:summary>Keywords pertaining to a vertical stratum</doc:summary>
+            <doc:description>Keywords naming vertical strata associated 
+            with the data set (e.g., soil horizons).</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="temporal">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Temporal Keywords</doc:tooltip>
+            <doc:summary>Keywords pertaining to temporal data</doc:summary>
+            <doc:description>Keywords listing time periods associated 
+            with the data set.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="theme">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Thematic Keywords</doc:tooltip>
+            <doc:summary>Keywords pertaining to thematic subject</doc:summary>
+            <doc:description>Keywords naming thematics subjects associated 
+            with the data set.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="taxonomic">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Taxonomic Keywords</doc:tooltip>
+            <doc:summary>Keywords pertaining to taxon information</doc:summary>
+            <doc:description>Keywords listing taxonomic terms associated 
+            with the data set.  Note that lists of species names or other taxon
+            lists should be presented in the taxonomicCoverage element.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="yearDate">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Year or Date</doc:tooltip>
+        <doc:summary>A type allowing a year or date value</doc:summary>
+        <doc:description>This type is the union of the built-in types for year
+        and date.</doc:description>
+        <doc:example>1999, or 2001-03-15</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:union memberTypes="xs:gYear xs:date"/>
+  </xs:simpleType>
+  <xs:simpleType name="IDType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Identifer</doc:tooltip>
+        <doc:summary>A unique identifier for this additional
+        metadata that can be used to reference it elsewhere.
+        </doc:summary>
+        <doc:description>A unique identifier for this additional
+        metadata that can be used to reference it elsewhere.
+        This is a formal field in that it is an error to provide
+        a value for the id attribute that is not unique within
+        the document's set of id attributes. This is designed to
+        allow other portions of the metadata to reference this
+        section formally.</doc:description>
+        <doc:example>knb.343.22</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:list itemType="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="SystemType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Identifer System</doc:tooltip>
+        <doc:summary>The data management system within which an
+        identifier is in scope and therefore unique.
+        </doc:summary>
+        <doc:description>The data management system within which an
+        identifier is in scope and therefore unique. This is typically
+        a URL (Uniform Resource Locator) that indicates a data
+        management system.  All identifiers that share a system must
+        be unique. In other words, if the same identifier is used in
+        two locations with identical systems, then by definition the
+        objects at which they point are in fact the same object.
+        </doc:description>
+        <doc:example>http://metacat.somewhere.org/svc/mc/</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:list itemType="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="ScopeType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Identifer Scope</doc:tooltip>
+        <doc:summary>The scope of the identifier.</doc:summary>
+        <doc:description>The scope of the identifier.  Scope is generally
+        set to either "system", meaning that it is scoped according to
+        the "system" attribute, or "document" if it is only to be in scope
+        within this single document instance.  In this particular use of
+        scope, it is FIXED to be "system" because the packageId is
+        required and always has the scope of the required "system".
+        </doc:description>
+        <doc:example>system</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="system"/>
+      <xs:enumeration value="document"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="FunctionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="download"/>
+      <xs:enumeration value="information"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DistributionType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Distribution Information</doc:tooltip>
+        <doc:summary>Distribution information for accessing the
+              resource.</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>Distribution information for accessing the
+              resource by one of three methods: online, offline or inline. Generally, 
+              the Type at the resource level is intended to be informational, although 
+              elements are
+              included to describe a complex connection protocol.
+             </para>
+            <para>For more information, see the sub-elements. Also
+             compare to 
+             <ulink url="./eml-physical.html#PhysicalDistributionType">
+                <citetitle>
+             phys:PhysicalDistributionType</citetitle>
+              </ulink>.
+             
+             
+             </para>
+          </section>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:choice>
+        <xs:element name="online" type="OnlineType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>distribution/online</doc:tooltip>
+              <doc:summary>Online distribution information</doc:summary>
+              <doc:description>This element contains information for accessing the
+              resource online, represented either as a URL a connection, or 
+              a connectionDefinition which may be referenced in other parts of
+              the EML document. See the Type definition for more information. </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="offline" type="OfflineType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Offline distribution</doc:tooltip>
+              <doc:summary>data are available offline</doc:summary>
+              <doc:description>This element is for data which are distributed offline, 
+         generally by request. See the Type 
+        definition for more information.         </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="inline" type="InlineType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Inline distribution</doc:tooltip>
+              <doc:summary>data distributed inline in the metadata.</doc:summary>
+              <doc:description>The data are distributed inline, with the metadata. See the Type 
+        definition for more information.         </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:group ref="ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="IDType" use="optional"/>
+    <xs:attribute name="system" type="SystemType" use="optional"/>
+    <xs:attribute name="scope" type="ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="ConnectionDefinitionType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Connection Definition</doc:tooltip>
+        <doc:summary>Definition of the connection protocol.   </doc:summary>
+        <doc:description>Definition of the connection protocol.   
+        The definition has a "scheme" which identifies the
+                            protocol by name, with a detailed description 
+                            and its required parameters. A connectionDefinition 
+                    lists all of the parameters needed for the connection
+                    and possible default values for each. A definition provided in this
+                    element may be used in other parts of the EML document.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="schemeName">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Scheme Name</doc:tooltip>
+              <doc:summary>The name of the scheme used to identify this
+              connection.</doc:summary>
+              <doc:description>The name of the scheme used to identify this
+              connection.  The scheme name is qualified by its system attribute.
+              The scheme name implies a particular protocol for
+              accessing information from the connection.  Applications must
+              have a knowledge of the scheme or be able to deduce the protocol
+              from the scheme description in order to effectively access data
+              over the connection.  Many schemes will be unknown to client
+              applications.  At some later point in time a registry for
+              connection schemes may be established in order to promote
+              application interoperability, and we may expand this portion of
+              EML to adopt a more comprehensive standard such as WSDL, but for
+              now this simpler description is provided.</doc:description>
+              <doc:example>metacat</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="system" type="SystemType" use="optional">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Scheme System</doc:tooltip>
+                      <doc:summary>The system in which this scheme name is
+                      relevant</doc:summary>
+                      <doc:description>The computing system within which this
+                      scheme name has relevance. This attribute qualifies the
+                      scheme name in order to decrease the likelihood of scheme
+                      name collisions when more that one EML user defines a
+                      scheme name with the same name but different semantics.
+                      </doc:description>
+                      <doc:example>
+                      http://knb.ecoinformatics.org/knb/</doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="description" type="txt:TextType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Scheme Description</doc:tooltip>
+              <doc:summary>The description of the scheme used to identify this
+              connection.</doc:summary>
+              <doc:description>The description of the scheme used to identify
+              this connection. The scheme name implies a particular protocol for
+              accessing information from the connection.  Applications must
+              have a knowledge of the scheme or be able to deduce the protocol
+              from the scheme description in order to effectively access data
+              over the connection.</doc:description>
+              <doc:example>The metacat application protocol.  Applications
+              must first log into metacat by sending an HTTP POST request
+              in http-url-encoded format with the parameters action, username,
+              and password.  Action must be set to "login".
+              If authentication is successful, the metacat
+              server will respond with a session cookie.  All future requests
+              should include the session cookie in the HTTP header.  To
+              retrieve an object, the client then would send an HTTP POST
+              in http-url-encoded format, with an action parameter set to
+              "get" and the docid parameter set to the identifier for the
+              desired object.  The response will either be an XML document
+              or a multipart-form-encoded response containing data.
+              </doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="parameterDefinition" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Parameter Definition</doc:tooltip>
+              <doc:summary>The definition of a parameter that is needed to
+              properly use this connection scheme.</doc:summary>
+              <doc:description>The definition of a parameter that is needed to
+              properly use this connection scheme.  Each parameter has a name
+              and a definition that are used by applications to assess the type
+              of information needed for the request.  Parameters may also set
+              default values that are used if a connection does not provide a
+              value for a parameter.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="name" type="NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Parameter Name</doc:tooltip>
+                    <doc:summary>The Name of a parameter that is needed to
+                    properly use this connection scheme.</doc:summary>
+                    <doc:description>The name of a parameter that is needed to
+                    properly use this connection scheme.</doc:description>
+                    <doc:example>hostname</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="definition" type="NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Parameter Definition</doc:tooltip>
+                    <doc:summary>The definition of a parameter that is needed
+                    to properly use this connection scheme.</doc:summary>
+                    <doc:description>The definition of a parameter that is
+                    needed to properly use this connection scheme.  The
+                    definition is used by applications to assess the type
+                    of information needed for the request.</doc:description>
+                    <doc:example>The fully qualified name of the internet host
+                    that is providing the metacat service, as would be returned
+                    by a Domain Name System (DNS) query.</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="defaultValue" type="NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Default Parameter Value</doc:tooltip>
+                    <doc:summary>The default value for a parameter that is
+                    needed to properly use this connection scheme.</doc:summary>
+                    <doc:description>The default value for a parameter that is
+                    needed to properly use this connection scheme.  If a default
+                    value is set, then it should be used for connections that
+                    do not override the default with a connection-specific
+                    value. This allows a definition to be established that
+                    declares common information that might be shared by several
+                    connections as default values.  Parameter values provided
+                    in the connection always override any default values
+                    provided in the connection definition.</doc:description>
+                    <doc:example>metacat.nceas.ucsb.edu</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="IDType" use="optional"/>
+    <xs:attribute name="system" type="SystemType" use="optional"/>
+    <xs:attribute name="scope" type="ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <!--
+
+inline type -->
+  <xs:complexType name="InlineType" mixed="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Inline distribution</doc:tooltip>
+        <doc:summary>Object data distributed inline in the metadata.
+              </doc:summary>
+        <doc:description>Object data distributed inline in the metadata.
+              Users have the option of including the data right inline in the
+              metadata by providing it inside of the "inline" element.  For
+              many text formats, the data can be simply included directly in
+              the element.  However, certain character sequences are invalid in
+              an XML document (e.g., &lt;), so care will need to be taken to 
+              either 1) wrap the data in a CDATA section if needed, or 
+              2) encode the data using a text encoding algorithm such as
+              base64, and then include that in a CDATA section.  The latter
+              will be necessary for binary formats.
+              </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexContent mixed="true">
+      <xs:restriction base="xs:anyType">
+        <xs:sequence>
+          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OfflineType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>medium of the resource</doc:tooltip>
+        <doc:summary>the medium on which this resource is distributed,
+              either digitally or as hardcopy</doc:summary>
+        <doc:description>the medium on which this resource is distributed
+              digitally, such as 3.5" floppy disk, or various tape media types,
+              or 'hardcopy'</doc:description>
+        <doc:example>CD-ROM, 3.5 in. floppy disk, Zip disk</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="mediumName" type="NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Medium name</doc:tooltip>
+            <doc:summary>Name of the medium that for this resource
+                    distribution</doc:summary>
+            <doc:description>Name of the medium on which this resource
+                    is distributed. Can be various digital media such as tapes
+                    and disks, or printed media which can collectively be
+                    termed 'hardcopy'.</doc:description>
+            <doc:example>Tape, 3.5 inch Floppy Disk,
+                    hardcopy</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mediumDensity" type="NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>density of the digital medium</doc:tooltip>
+            <doc:summary>the density of the digital medium if this is
+                    relevant.</doc:summary>
+            <doc:description>the density of the digital medium if this
+                    is relevant. Used mainly for floppy disks or
+                    tape.</doc:description>
+            <doc:example>High Density (HD), Double Density
+                    (DD)</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mediumDensityUnits" type="NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>units of a numerical density</doc:tooltip>
+            <doc:summary>a numerical density's units</doc:summary>
+            <doc:description>if a density is given numerically, the
+                    units should be given here.</doc:description>
+            <doc:example>B/cm</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mediumVolume" type="NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>storage volume</doc:tooltip>
+            <doc:summary>total volume of the storage
+                    medium</doc:summary>
+            <doc:description>the total volume of the storage medium on
+                    which this resource is shipped.</doc:description>
+            <doc:example>650 MB</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mediumFormat" type="NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>medium format</doc:tooltip>
+            <doc:summary>format of the medium on which the resource is
+                    shipped.</doc:summary>
+            <doc:description>the file system format of the medium on
+                    which the resource is shipped</doc:description>
+            <doc:example>NTFS, FAT32, EXT2, QIK80</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mediumNote" type="NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>note about the media</doc:tooltip>
+            <doc:summary>note about the media</doc:summary>
+            <doc:description>any additional pertinent information about
+                    the media</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OnlineType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Online Distribution Type</doc:tooltip>
+        <doc:summary>Distribution information for accessing the
+              resource online.</doc:summary>
+        <doc:description>
+          <section xmlns="">
+            <para>Distribution information for accessing the
+              resource online, represented either as a URL or as the series of
+              named parameters needed to connect. The URL field can contain 
+              a simple web address or an entire query string. The connection
+               element allows the components of a complex protocol to 
+               be described individually. The connectionDefinition element 
+               can also be appear outside of the connection elements, 
+               so that it can be defined once and referenced by several connections. 
+               </para>
+            <para>
+               Also see the 
+               <ulink url="./eml-physical.html#PhysicalOnlineType">
+                <citetitle>phys:PhysicalOnlineType</citetitle></ulink>, 
+               which may be more
+               appropriate for describing the online connections to a specific entity
+               described by this metadata document.
+               </para>
+          </section>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="onlineDescription" type="i18nNonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Description of online information</doc:tooltip>
+            <doc:summary>Brief description of the the content of online</doc:summary>
+            <doc:description>This element can hold a brief description of the content 
+            of the online element's online|offline|inline child. This description element could 
+            supply content for an html anchor tag. 
+</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice>
+        <xs:element name="url" type="UrlType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>URL</doc:tooltip>
+              <doc:summary>A URL or this resource.</doc:summary>
+              <doc:description>A URL (Uniform Resource Locator) from which this additional 
+              information can be obtained, or from which the resource can be downloaded 
+              directly. In the resource module, the distribution URL is generally meant for 
+              informational purposes, and the "function" attribute should be set to "information". 
+              However, if the URL returns the data stream itself, then the "function" attribute 
+              should be set to "download".  See the Type Definition for more information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="connection" type="ConnectionType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Connection</doc:tooltip>
+              <doc:summary>A connection to a data service</doc:summary>
+              <doc:description>A description of the information needed to make an application 
+              connection to a data service. The connection contains a connectionDefinition 
+              and optional parameters for overriding defaults. See the Type Definition for 
+              more information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="connectionDefinition" type="ConnectionDefinitionType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Connection Definition</doc:tooltip>
+              <doc:summary>The definition of a connection
+        that will be used in another location in the EML
+        document                         
+                            </doc:summary>
+              <doc:description>
+The definition of a type of connection
+        that will be used in another location in the EML
+        document. The connectionDefinition element only provides the definition of the
+        protocol and its parameters, but not the actual values
+        to be used to make the connection (instead, see the
+        connection element).  This connectionDefinition may be
+        used by multiple connections (e.g., to download different files
+        from the same database), but each connection must provide or
+        reference a valid connection definition.              
+              
+     The definition has a "scheme" which identifies the
+                            protocol by name, with a detailed description 
+                            and its required parameters. A connectionDefinition 
+                    lists all of the parameters needed for the connection
+                    and possible default values for each. </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+  <!-- 
+
+URL Type -->
+  <xs:complexType name="UrlType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Download site URL</doc:tooltip>
+        <doc:summary>A URL (Uniform Resource Locator) from which
+                    this resource can be downloaded or information can be
+                    obtained about downloading it.</doc:summary>
+        <doc:description>A URL (Uniform Resource Locator) from
+                    which this resource can be downloaded or additional
+                    information can be obtained. If the URL
+                    provides further information about downloading the
+                    object but does not directly return the data stream, then
+                    the "function" attribute should be set to "information".
+                    If accessing the URL would directly return the data stream, 
+                    then the "function" attribute should be set to "download".  
+                    If the "function" attribute is omitted, then "download"
+                    is implied for the URL function.
+                    In more complex cases where a non-standard connection
+                    must be established that complies with application
+                    specific procedures beyond what can be described in the
+                    simple URL, then the "connection" element should
+                    be used instead of the URL element.</doc:description>
+        <doc:example>
+                    http://data.org/getdata?id=98332</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:attribute name="function" type="FunctionType" use="optional" default="download"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!--
+
+connectionType -->
+  <xs:complexType name="ConnectionType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Connection</doc:tooltip>
+        <doc:summary>A description of the information needed
+                    to make an application connection to a data service.
+                    </doc:summary>
+        <doc:description>A description of the information needed
+                    to make an application connection to a data service.
+                    The connection starts with a connectionDefinition which
+                    lists all of the parameters needed for the connection
+                    and possible default values for each.  It may also include a
+                    list of parameter values (one for each), that
+                    override the defaults for this particular connection.
+                    One parameter element should exist for every
+                    parameterDefinition that is present in the
+                    connectionDefinition, although parameters that were
+                    defined with a defaultValue in their parameterDefinition
+                    can be omitted. All information about how to use the
+                    parameters to establish a session and extract data is
+                    present in the connectionDefinition, possibly implicitly
+                    by naming a connection schemeName that is well-known. 
+                    See descriptions
+                    of the child element types for further information.
+                    </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="connectionDefinition" type="ConnectionDefinitionType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Connection Definition</doc:tooltip>
+              <doc:summary>Connection Definition</doc:summary>
+              <doc:description>In a ConnectionType, the connectionDefinition element provides the definition of the protocol and its parameters. The definition has a "scheme" which identifies the protocol by name, with a detailed description and its required parameters. A connectionDefinition lists all of the parameters needed for the connection and possible default values for each.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Parameter</doc:tooltip>
+              <doc:summary>A parameter to be used to make this
+                            connection.</doc:summary>
+              <doc:description>A parameter to be used to make
+                            this connection. This value overrides any
+                            default value that may have been provided in the
+                            connection definition.
+                            </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="name" type="NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Parameter Name</doc:tooltip>
+                    <doc:summary>Name of the parameter to be
+                                  used to make this connection.</doc:summary>
+                    <doc:description>The name of the parameter
+                                  to be used to make this connection.
+                                  </doc:description>
+                    <doc:example>hostname</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="value" type="NonEmptyStringType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Parameter Value</doc:tooltip>
+                    <doc:summary>The value of the parameter to
+                                  be used to make this connection.
+                                  </doc:summary>
+                    <doc:description>The value of the parameter
+                                  to be used to make this connection. This
+                                  value overrides any default value that may
+                                  have been provided in the connection
+                                  definition.</doc:description>
+                    <doc:example>nceas.ucsb.edu</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="IDType" use="optional"/>
+    <xs:attribute name="system" type="SystemType" use="optional"/>
+    <xs:attribute name="scope" type="ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:simpleType name="NonEmptyStringType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Non Empty String Type</doc:tooltip>
+        <doc:summary>Non Empty String Type</doc:summary>
+        <doc:description>This type specifies a content pattern for all elements 
+          that are required by EML to ensure that there is actual content (i.e., 
+          not just whitespace). The pattern described can be interpreted as
+          "at least one non-whitespace character, followed
+          by any number of whitespace plus not-whitespace characters. "
+          Leading and/or trailing whitespace is allowed, and whitespace 
+          may include carriage returns and newlines.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:pattern value="[\s]*[\S][\s\S]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+	
+	<xs:complexType name="i18nNonEmptyStringType" mixed="true">
+		<xs:annotation>
+	      <xs:appinfo>
+	        <doc:tooltip>i18n Non Empty String Type</doc:tooltip>
+	        <doc:summary>i18n Non Empty String Type</doc:summary>
+	        <doc:description>This type specifies a content pattern for all elements 
+	          that require language translations. The xml:lang attribute
+	          can be used to define the default language for element content.
+	          Additional translations should be included as child 'value'
+	          elements that also have an optional xml:lang attribute.</doc:description>
+	      </xs:appinfo>
+	    </xs:annotation>
+		<xs:sequence>
+			<xs:element name="value" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:annotation>
+				      <xs:appinfo>
+				        <doc:tooltip>i18n Value</doc:tooltip>
+				        <doc:summary>i18n Value</doc:summary>
+				        <doc:description>Allows multiple language translations 
+				        to appear as children of a mixed-content parent element. The xml:lang attribute
+				        is optional and will override any xml:lang attribute that has been
+				        specified in the ancestor elements. The content is subject to the same
+				        rules defined by NonEmptyStringType. </doc:description>
+				      </xs:appinfo>
+				    </xs:annotation>
+					<xs:simpleContent>
+						<xs:extension base="NonEmptyStringType">
+							<xs:attribute ref="xml:lang" use="optional"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute ref="xml:lang" use="optional" />
+	</xs:complexType>
+  
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-software.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-software.xsd
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="eml://ecoinformatics.org/software-2.1.1" xmlns:res="eml://ecoinformatics.org/resource-2.1.1" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:proj="eml://ecoinformatics.org/project-2.1.1" xmlns:acc="eml://ecoinformatics.org/access-2.1.1" xmlns:phys="eml://ecoinformatics.org/physical-2.1.1" targetNamespace="eml://ecoinformatics.org/software-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/access-2.1.1" schemaLocation="eml-access.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/project-2.1.1" schemaLocation="eml-project.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/physical-2.1.1" schemaLocation="eml-physical.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+    '$RCSfile: eml-software.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.50 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-software</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-software module - Software specific
+              information
+            </title>
+            <para>
+              The eml-software module contains general information that
+              describes software resources.  This module is intended to fully
+              document software that is needed in order to view a resource
+              (such as a dataset) or to process a dataset.  The software
+              module is also imported into the eml-methods module in order to
+              document what software was used to process or perform quality
+              control procedures on a dataset.
+            </para>
+            <para>
+              The eml-software module, like other modules, may be
+              "referenced" via the &lt;references&gt; tag.  This
+              allows a software resource to be described once, and then used
+              as a reference in other locations within the EML document via
+              its ID.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>All datasets where software was used in
+        the analysis or creation of the dataset.</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="software" type="SoftwareType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Software Package</doc:tooltip>
+        <doc:summary>Defines a software distribution and all of its dependent
+        software.</doc:summary>
+        <doc:description>The software element contains general information
+        about a software resource that is being documented. This field is
+        intended to give information for software tools that are needed to
+        interpret a dataset, software that was written to process a resource,
+        or software as a resource in itself. It is based on eml-resource and
+        Open Software Description (OSD) a W3C submission. There can be multiple
+        implementations within a software package because a physical software
+        package can run on multiple hardware and/or operating systems. See
+        implementation element documentation for a more thorough
+        explanation.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="SoftwareType">
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="res:ResourceGroup"/>
+        <xs:element name="implementation" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Implementation</doc:tooltip>
+              <doc:summary>Describes the hardware and/or operating system
+              requirements for one implementation of a package.</doc:summary>
+              <doc:description>Implementation describes the hardware, operating
+              system resources a package runs on. Note, a package can have
+              multiple implementations. So for example, a package may be
+              written in java and the package may run on numerous hardware
+              and/or operating systems like Pentium/Linux, Pentium/NT and so
+              on. Hardware and Software descriptions that have different
+              requirements can be placed here.</doc:description>
+              <doc:example>Please see the examples for each sub-element of the
+              implementation type.</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="distribution" type="phys:PhysicalDistributionType" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Distribution</doc:tooltip>
+                    <doc:summary>Information on how the resource is distributed
+                   online and offline</doc:summary>
+                    <doc:description>This field provides information on how the
+                   resource is distributed online and offline. Connections to
+                   online systems can be described as URLs and as a list of
+                   relevant connection parameters.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="size" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Physical Size</doc:tooltip>
+                    <doc:summary>Physical size of an implementation.
+                    </doc:summary>
+                    <doc:description>The physical size of an implementation on
+                    disk.</doc:description>
+                    <doc:example>100 Megabytes</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="language" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>International Language</doc:tooltip>
+                    <doc:summary>The International Language of the software
+                    implementation.</doc:summary>
+                    <doc:description>The International Language of the software
+                    implementation.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="LanguageValue" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Language Value</doc:tooltip>
+                          <doc:summary>The actual value for the language or
+                          a code for the language.</doc:summary>
+                          <doc:description>The actual value for the language or
+                          a code for the language.</doc:description>
+                          <doc:example>english</doc:example>
+                          <doc:example>eng</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="LanguageCodeStandard" type="res:NonEmptyStringType" minOccurs="0">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Language Code Standard</doc:tooltip>
+                          <doc:summary>The International Language Code being
+                          used in the field languageValue.</doc:summary>
+                          <doc:description>The International Language Code being
+                          used in the field languageValue. See
+                          http://www.loc.gov/standards/iso639-2/</doc:description>
+                          <doc:example>ISO639-2</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="operatingSystem" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Operating System</doc:tooltip>
+                    <doc:summary>The operating system(s) an implementation runs
+                    on.</doc:summary>
+                    <doc:description>The operating system(s) an implementation runs
+                    on.</doc:description>
+                    <doc:example>Linux</doc:example>
+                    <doc:example>Windows 95</doc:example>
+                    <doc:example>Windows NT4</doc:example>
+                    <doc:example>Windows XP</doc:example>
+                    <doc:example>Sun Solaris 2.8</doc:example>
+                    <doc:example>Mac OS X</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="machineProcessor" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Machine Processor</doc:tooltip>
+                    <doc:summary>The machine processor(s) required for
+                    executing the implementation.</doc:summary>
+                    <doc:description>The Machine Processor required for
+                    executing the implementation.</doc:description>
+                    <doc:example>Pentium II</doc:example>
+                    <doc:example>Intel 486</doc:example>
+                    <doc:example>SUN Sparc</doc:example>
+                    <doc:example>Motorola</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="virtualMachine" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Virtual Machine</doc:tooltip>
+                    <doc:summary>The virtual machine that the implementation
+                    requires.</doc:summary>
+                    <doc:description>The virtual machine that the implementation
+                    requires.</doc:description>
+                    <doc:example>Java Virtual Machine 1.2</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="diskUsage" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Disk Usage</doc:tooltip>
+                    <doc:summary>The minimum amount of Disk Space required to
+                    install this implementation.</doc:summary>
+                    <doc:description>The minimum amount of Disk Space required to
+                    install this implementation.</doc:description>
+                    <doc:example>220 Megabytes</doc:example>
+                    <doc:example>15 MB</doc:example>
+                    <doc:example>100 kB</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="runtimeMemoryUsage" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Runtime Memory Usage</doc:tooltip>
+                    <doc:summary>The minimum amount of memory required to run
+                    an implementation.</doc:summary>
+                    <doc:description>The minimum amount of memory required to run
+                    an implementation.</doc:description>
+                    <doc:example>32 Megabytes</doc:example>
+                    <doc:example>128 MB</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="programmingLanguage" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Programming Language</doc:tooltip>
+                    <doc:summary>The computer programming language the software
+                    package was programmed in.</doc:summary>
+                    <doc:description>The computer programming language the software
+                    package was programmed in.</doc:description>
+                    <doc:example>C++</doc:example>
+                    <doc:example>Java</doc:example>
+                    <doc:example>C</doc:example>
+                    <doc:example>C#</doc:example>
+                    <doc:example>Perl</doc:example>
+                    <doc:example>Cobol</doc:example>
+                    <doc:example>Fortran</doc:example>
+                    <doc:example>Lisp</doc:example>
+                    <doc:example>Visual Basic</doc:example>
+                    <doc:example>VBA</doc:example>
+                    <doc:example>Bourne Shell Script</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="checksum" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Checksum</doc:tooltip>
+                    <doc:summary>The generated checksum value of a software
+                    package that is a self-contained module.</doc:summary>
+                    <doc:description>The generated checksum value of a software
+                    package that is a self-contained module.</doc:description>
+                    <doc:example>$sum software.jar 27021 22660</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>dependency</doc:tooltip>
+                    <doc:summary>This fields documents any dependencies
+                    that this implementation might have.</doc:summary>
+                    <doc:description>This fields documents any dependencies
+                    that this implementation might have.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>dependency</doc:tooltip>
+              <doc:summary>This fields documents any dependencies
+              that this software package in general might have.</doc:summary>
+              <doc:description>This fields documents any dependencies
+              that this software package in general might have.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="licenseURL" type="res:NonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>URL for License</doc:tooltip>
+                <doc:summary>URL where the license can be found</doc:summary>
+                <doc:description>URL where the license can be found</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="license" type="res:NonEmptyStringType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>License</doc:tooltip>
+                <doc:summary>Text of the license</doc:summary>
+                <doc:description>Text of the license</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="version" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Version</doc:tooltip>
+              <doc:summary>Version of the software being
+              packaged.</doc:summary>
+              <doc:description>String value corresponding to the major, minor,
+              custom, and build version.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="project" type="proj:ResearchProjectType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>project descriptor</doc:tooltip>
+              <doc:summary/>
+              <doc:description>This field is a description of the project with
+           which this software product is related.  Please see the eml-project
+           module for more information.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:simpleType name="Action">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Action</doc:tooltip>
+        <doc:summary>Describes what action needs to be undertaken (if any) for
+        a software dependency at either the software package or implementation
+        level.</doc:summary>
+        <doc:description>This element and its enumerations of assert and
+        install can be used as commands by a software application to carry out
+        these actions on software package dependencies. This is a change from
+        how we have used all previous elements within eml. Up until now all
+        other elements have been simply metadata designed to describe data,
+        literature citations, etc... with the Action element we can use this
+        module as a command to carry out the action.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="install"/>
+      <xs:enumeration value="assert"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="dependency">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Dependency</doc:tooltip>
+        <doc:summary>Dependency describes the software package(s) that the
+        software package is dependent upon.</doc:summary>
+        <doc:description>The dependency element is recursive. It is a
+        sub-element of the software Element but it also has as a sub-element
+        its parent element Software Package. Dependency has been made optional
+        because to make it mandatory does not allow the recursion to end.
+        Dependency has also been made a sub-element of implementation because
+        there can be both implementation and package level dependencies within
+        a package.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="action" type="Action">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Action</doc:tooltip>
+              <doc:summary>Describes what action needs to be undertaken (if any)
+           for a software dependency at either the software package or
+           implementation level.</doc:summary>
+              <doc:description>This element and its enumerations of assert and
+           install can be used as commands by a software application to carry
+           out these actions on software package dependencies. This is a change
+           from how we have used all previous elements within eml. Up until now
+           all other elements have been simply metadata designed to describe
+           data, literature citations, etc... with the Action element we can
+           use this module as a command to carry out the action.
+           </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="software"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-spatialRaster.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-spatialRaster.xsd
@@ -1,0 +1,941 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+xmlns="eml://ecoinformatics.org/spatialRaster-2.1.1" 
+xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+xmlns:con="eml://ecoinformatics.org/constraint-2.1.1" 
+xmlns:att="eml://ecoinformatics.org/attribute-2.1.1" 
+xmlns:ent="eml://ecoinformatics.org/entity-2.1.1" 
+xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" 
+xmlns:spref="eml://ecoinformatics.org/spatialReference-2.1.1" 
+xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+targetNamespace="eml://ecoinformatics.org/spatialRaster-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/spatialReference-2.1.1" schemaLocation="eml-spatialReference.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/entity-2.1.1" schemaLocation="eml-entity.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/attribute-2.1.1" schemaLocation="eml-attribute.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/constraint-2.1.1" schemaLocation="eml-constraint.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+    Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.50 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA    
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-spatialRaster</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-spatialRaster module - Logical information about
+              regularly gridded geospatial image data
+            </title>
+            <para>
+              The eml-spatialRaster module allows for the description of
+              entities composed of rectangular grids of data values that are
+              usually georeferenced to a portion of the earth's surface.
+              Specific attributes of a spatial raster can be documented
+              here including the spatial organization of the raster cells,
+              the cell data values, and if derived via imaging sensors,
+              characteristics about the image and its individual bands.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all spatial datasets that use spatial gridded
+        data</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="spatialRaster" type="SpatialRasterType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Spatial Raster</doc:tooltip>
+        <doc:summary>Description of a GIS layer composed of raster
+        pixels.</doc:summary>
+        <doc:description>Description of a GIS layer composed of raster pixels
+        comprising a regular-pattern grid. Generally, a raster object may be
+        thought of as a pattern of closely spaced rows of dots that
+        collectively form an image. Raster spatial objects are used to locate
+        zero-, two-, or three-dimensional locations in the
+        dataset</doc:description>
+        <doc:example>An interpolated grid of irregularly spaced data is an
+        example of this element.</doc:example>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="SpatialRasterType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Spatial Raster Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="ent:EntityGroup"/>
+        <xs:element name="attributeList" type="att:AttributeListType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute List</doc:tooltip>
+              <doc:summary>The list of attributes associated with this
+              entity.</doc:summary>
+              <doc:description>The list of attributes associated with this
+              entity.  For more information see the eml-attribute
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="constraint" type="con:ConstraintType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Constraint</doc:tooltip>
+              <doc:summary>Description of any relational constraints on 
+              this entity.</doc:summary>
+              <doc:description>Description of any relational constraints on 
+              this entity.  For more information see the eml-constraint
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="spatialReference" type="spref:SpatialReferenceType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Spatial Reference</doc:tooltip>
+              <doc:summary>The means by which positional information in this entity is
+              related to points on the earth's surface.</doc:summary>
+              <doc:description>Spatial Referencing systems define the coordinates used to
+              describe horizontal and vertical locations. These are typically either geographic, projected
+              planar, or arbitrary planar.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="georeferenceInfo" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Georeferenc information</doc:tooltip>
+              <doc:summary>Information on how to position the grid within the coordinate
+                    system defined in the spatial reference module.</doc:summary>
+              <doc:description>Information on how to position the grid within the coordinate
+                    system defined in the spatial reference module. </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="cornerPoint" maxOccurs="4">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Corner point</doc:tooltip>
+                    <doc:summary>Location of a corner on a rectified grid within the coordinate 
+                    system.</doc:summary>
+                    <doc:description>Location of a corner on the coordinate system defined in
+                    the spatial reference module. Use this element when the rows and columns
+                     of the grid are aligned with the coordinate system. One or more corner 
+                     points are needed to locate a rectified grid.
+                          </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="xCoordinate" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>X coordinate</doc:tooltip>
+                          <doc:summary>X Location of the georeferencing point in the X diminsion of the 
+                       coordinate system.</doc:summary>
+                          <doc:description>Location of the georeferencing point expressed in units of the
+                           coordinate system
+                      defined in the spatial Reference module.</doc:description>
+                          <doc:example>455000</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="yCoordinate" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Y coordinate</doc:tooltip>
+                          <doc:summary>Location of the georeferencing point in the Y dimension of the
+                       coordinate system.</doc:summary>
+                          <doc:description>Y Location of the georeferencing point expressed in units of the coordinate system
+                      defined in the spatial Reference module.</doc:description>
+                          <doc:example>3455000</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="pointInPixel">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Point in Pixel</doc:tooltip>
+                          <doc:summary>Location within the pixel of the georeferencing point.</doc:summary>
+                          <doc:description>Location within the pixel of the georeferencing point.</doc:description>
+                          <doc:example>upperLeft</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="upperLeft"/>
+                          <xs:enumeration value="upperRight"/>
+                          <xs:enumeration value="lowerRight"/>
+                          <xs:enumeration value="lowerLeft"/>
+                          <xs:enumeration value="center"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="corner" type="rasterOriginType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Corner</doc:tooltip>
+                          <doc:summary>Identification of the corner in the grid corresponding to the   
+                    coordinates provided.</doc:summary>
+                          <doc:description>Identification of the corner in the grid corresponding to the   
+                    coordinates provided. 
+              </doc:description>
+                          <doc:example>Upper Left</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="controlPoint" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Georeference Point</doc:tooltip>
+                    <doc:summary>A point defined in both grid cell and georeferenced 
+                    coordinates that is used to position  the raster grid within the 
+                    coordinate system defined in the spatialReference modoule.</doc:summary>
+                    <doc:description>If the grid is rectified to the coordinate system, then
+                     a single point may be used to position the grid. Otherwise, a series of 
+                     points is necessary to fit the grid to the coordinate system. 
+              </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="column" type="xs:int">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Column</doc:tooltip>
+                          <doc:summary>Column location of the georeferencing point in the grid.</doc:summary>
+                          <doc:description>Column location of the georeferencing point indicated as the nth column
+                      counting the cell indicated in rasterOrigin as column 1.</doc:description>
+                          <doc:example>1</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="row" type="xs:int">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Row</doc:tooltip>
+                          <doc:summary>Row location of the georeferencing point in the grid.</doc:summary>
+                          <doc:description>Row location of the georeferencing point indicated as the nth row
+                      counting the cell indicated in rasterOrigin as row 1.</doc:description>
+                          <doc:example>1</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="xCoordinate" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>X coordinate</doc:tooltip>
+                          <doc:summary>X Location of the georeferencing point in the X diminsion of the 
+                       coordinate system.</doc:summary>
+                          <doc:description>Location of the georeferencing point expressed in units of the coordinate system
+                      defined in the spatial Reference module.</doc:description>
+                          <doc:example>455000</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="yCoordinate" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Y coordinate</doc:tooltip>
+                          <doc:summary>Location of the georeferencing point in the Y dimension of the
+                       coordinate system.</doc:summary>
+                          <doc:description>Y Location of the georeferencing point expressed in units of the
+                           coordinate system
+                      defined in the spatial Reference module.</doc:description>
+                          <doc:example>3455000</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="pointInPixel">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Point in Pixel</doc:tooltip>
+                          <doc:summary>Location within the pixel of the georeferencing point.</doc:summary>
+                          <doc:description>Location within the pixel of the georeferencing point.</doc:description>
+                          <doc:example>upperLeft</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="upperLeft"/>
+                          <xs:enumeration value="upperRight"/>
+                          <xs:enumeration value="lowerRight"/>
+                          <xs:enumeration value="lowerLeft"/>
+                          <xs:enumeration value="center"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="bilinearFit">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Bilinear Fit</doc:tooltip>
+                    <doc:summary>Terms of a bilinear model to fit the grid to the coordinate system.
+                          </doc:summary>
+                    <doc:description>Intercept and slope terms to describe the orientation and position of the
+                          grid to the coordinate system based on corner point identified in the rasterOrigin element.
+                      defined in the spatial Reference module.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="xIntercept" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>X Intercept</doc:tooltip>
+                          <doc:summary>Location of the rasterOrigin point on the x axis of the the coordinate system.
+                          </doc:summary>
+                          <doc:description>X Intercept of the rasterOrigin point within the coordinate system.
+                          </doc:description>
+                          <doc:example>3455000</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="xSlope" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>X slope</doc:tooltip>
+                          <doc:summary>Slope describing transformation of grid cell distances into x coordinates. 
+                          </doc:summary>
+                          <doc:description>Slope describing transformation of grid cell distances into x coordinates.
+                           </doc:description>
+                          <doc:example>5.0123</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="yIntercept" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Y Intercept</doc:tooltip>
+                          <doc:summary>Location of the rasterOrigin point on the y axis of the the coordinate 
+                          system. </doc:summary>
+                          <doc:description>Location of the rasterOrigin point on the y axis of the the coordinate
+                           system. </doc:description>
+                          <doc:example>455000</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="ySlope" type="xs:float">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>X slope</doc:tooltip>
+                          <doc:summary>Slope describing transformation of grid cell distances into y axis 
+                          coordinates.  </doc:summary>
+                          <doc:description>Slope describing transformation of grid cell distances into y axis 
+                          coordinates. </doc:description>
+                          <doc:example>5.0123</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="horizontalAccuracy" type="DataQuality">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Horizontal Accuracy</doc:tooltip>
+              <doc:summary>
+              The accuracy of horizontal locational measurements within the data.
+              </doc:summary>
+              <doc:description>Horizontal accuracy may be reported either as a quantitative estimate
+              expressed in the units of the coordinate system or as a text assessment.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="verticalAccuracy" type="DataQuality">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Vertical Accuracy</doc:tooltip>
+              <doc:summary>The accuracy of vertical locational measurements within the data.
+</doc:summary>
+              <doc:description>Vertical accuracy may be reported either as a quantitative estimate
+              expressed in the units of the height or depth measurement system or as a text
+              assessment.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="cellSizeXDirection">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Cell Size X Direction</doc:tooltip>
+              <doc:summary>The width of the cell in the x direction.</doc:summary>
+              <doc:description>Cell sizes should be expressed in the units declared in the spatialReference module.
+              </doc:description>
+              <doc:example>28.5</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="cellSizeYDirection">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Cell Size Y Direction</doc:tooltip>
+              <doc:summary>The width of the cell in the x direction.</doc:summary>
+              <doc:description>Cell sizes should be expressed in the units declared in the spatialReference module.
+              </doc:description>
+              <doc:example>28.5</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="numberOfBands">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Number Of Bands</doc:tooltip>
+              <doc:summary>The number of bands in the image.</doc:summary>
+              <doc:description>Image data may have more than one sensor band represented for each pixel.
+               </doc:description>
+              <doc:example>7</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="rasterOrigin" type="rasterOriginType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Raster Origin</doc:tooltip>
+              <doc:summary>The corner location of the pixel having the minimum
+              x and y values</doc:summary>
+              <doc:description>Identification the corner of the grid where the
+              first values for both the x and y axes begin in the
+              file. </doc:description>
+              <doc:example>Upper Left</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="rows" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Rows</doc:tooltip>
+              <doc:summary>Maximum number of raster objects along the ordinate
+              (y) axis</doc:summary>
+              <doc:description>Maximum number of raster objects along the
+              ordinate (y) axis</doc:description>
+              <doc:example>455</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="columns" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Columns</doc:tooltip>
+              <doc:summary>Maximum number of raster objects along the abscissa
+              (x) axis</doc:summary>
+              <doc:description>Maximum number of raster objects along the
+              abscissa (x) axis</doc:description>
+              <doc:example>455</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="verticals">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Verticals</doc:tooltip>
+              <doc:summary>Maximum number of raster objects along the vertical
+              (z) axis</doc:summary>
+              <doc:description>Maximum number of raster objects along the
+              vertical (z) axis.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="cellGeometry" type="CellGeometryType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Cell Geometry</doc:tooltip>
+              <doc:summary>Geometric representation of the cell's content.</doc:summary>
+              <doc:description>Indication of whether the cell value is representative of a single   
+              point(matrix) within the cell or the entire cell (pixel)</doc:description>
+              <doc:example>pixel</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="toneGradation" type="xs:integer" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Tone Gradation</doc:tooltip>
+              <doc:summary>Number of colors present in the image.
+              </doc:summary>
+              <doc:description>Number of colors present in the
+              image.</doc:description>
+              <doc:example>255</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="scaleFactor" type="res:NonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Scale Factor</doc:tooltip>
+              <doc:summary>The value used for scaling the source
+              raster.</doc:summary>
+              <doc:description>The scale factor is used for raster-rescaling
+              operations, where the following operation is applied to each
+              pixel in the data in the source:
+              rescaled=(source*scaleFactor)+offset.</doc:description>
+              <doc:example>2</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="offset" type="res:NonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Offset</doc:tooltip>
+              <doc:summary>The offset value used for scaling the source
+              raster.</doc:summary>
+              <doc:description>The offset is used for raster-rescaling
+              operations, where the following operation is applied to each
+              pixel in the data in the source:
+              rescaled=(source*scaleFactor)+offset.</doc:description>
+              <doc:example>20</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="imageDescription" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Image Description</doc:tooltip>
+              <doc:summary>Detailed information for data derived from image
+              sensors.</doc:summary>
+              <doc:description>Provides information about the image's
+              suitability for use, sensor properties, and individual band
+              descriptions.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="illuminationElevationAngle" type="xs:float" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Illumination Elevation Angle</doc:tooltip>
+                    <doc:summary>Illumination elevation measured in degrees
+                    clockwise from the target plane at intersection of the
+                    optical line of sight with the earth's
+                    surface.</doc:summary>
+                    <doc:description>Illumination elevation measured in degrees
+                    clockwise from the target plane at intersection of the
+                    optical line of sight with the earth's
+                    surface.</doc:description>
+                    <doc:example>45.5</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="illuminationAzimuthAngle" type="xs:float" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Illumination Azimuth Angle</doc:tooltip>
+                    <doc:summary>Illumination azimuth measured in degrees
+                    clockwise from true north at the time the image is
+                    taken.</doc:summary>
+                    <doc:description>Illumination azimuth measured in degrees
+                    clockwise from true north at the time the image is
+                    taken.</doc:description>
+                    <doc:example>45.5</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="imageOrientationAngle" type="xs:float" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Image Orientation Angle</doc:tooltip>
+                    <doc:summary>Angle from the first row of the image to true
+                    north in degrees, clockwise.</doc:summary>
+                    <doc:description>Angle from the first row of the image to
+                    true north in degrees, clockwise.</doc:description>
+                    <doc:example>45.5</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="imagingCondition" type="ImagingConditionCode" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Imaging Condition</doc:tooltip>
+                    <doc:summary>Code which indicates conditions which affect
+                    the quality of the image.</doc:summary>
+                    <doc:description>Code which indicates conditions which
+                    affect the quality of the image.</doc:description>
+                    <doc:example>cloud</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="imageQualityCode" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Image Quality Code</doc:tooltip>
+                    <doc:summary>Specifies the image quality.</doc:summary>
+                    <doc:description>Specifies the image
+                    quality.</doc:description>
+                    <doc:example>Excellent</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="cloudCoverPercentage" type="xs:float" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Cloud Cover Percentage</doc:tooltip>
+                    <doc:summary>Area of the dataset obscured by clouds,
+                    expressed as a percentage of the spatial
+                    extent.</doc:summary>
+                    <doc:description>Area of the dataset obscured by clouds,
+                    expressed as a percentage of the spatial
+                    extent.</doc:description>
+                    <doc:example>12</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="preProcessingTypeCode" type="res:NonEmptyStringType" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Preprocessing Type Code</doc:tooltip>
+                    <doc:summary>Image distributor's code that identifies the
+                    level of radiometric and geometric processing applied
+                    against the image.</doc:summary>
+                    <doc:description>Image distributor's code that identifies
+                    the level of radiometric and geometric processing applied
+                    against the image.</doc:description>
+                    <doc:example>LEVELl1A, SPOTVIEWORTHO</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="compressionGenerationQuality" type="xs:integer" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Compression Generation Quality</doc:tooltip>
+                    <doc:summary>Counts the number of lossy compression cycles
+                    performed on the image.</doc:summary>
+                    <doc:description>Counts the number of lossy compression
+                    cycles performed on the image.</doc:description>
+                    <doc:example>2</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="triangulationIndicator" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Triangulation Indicator</doc:tooltip>
+                    <doc:summary>Code which indicates whether or not
+                    triangulation has been performed upon the
+                    image.</doc:summary>
+                    <doc:description>Code which indicates whether or not
+                    triangulation has been performed upon the
+                    image.</doc:description>
+                    <doc:example>false</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="radiometricDataAvailability" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Radiometric Data Availability</doc:tooltip>
+                    <doc:summary>Code which indicates whether or not Standard
+                    Radiometric Product data is available.</doc:summary>
+                    <doc:description>Code which indicates whether or not
+                    Standard Radiometric Product data is
+                    available.</doc:description>
+                    <doc:example>false</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="cameraCalibrationInformationAvailability" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Camera Calibration Information
+                    Availability</doc:tooltip>
+                    <doc:summary>Code which indicates whether or not constants
+                    are available which allow for camera calibration
+                    corrections.</doc:summary>
+                    <doc:description>Code which indicates whether or not
+                    constants are available which allow for camera calibration
+                    corrections.</doc:description>
+                    <doc:example>false</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="filmDistortionInformationAvailability" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Film Distortion Information
+                    Availability</doc:tooltip>
+                    <doc:summary>Code which indicates whether or not
+                    Calibration Reseau information is available</doc:summary>
+                    <doc:description>Code which indicates whether or not
+                    Calibration Reseau information is
+                    available</doc:description>
+                    <doc:example>true</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="lensDistortionInformationAvailability" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Lens Distortion Information
+                    Availability</doc:tooltip>
+                    <doc:summary>Code which indicates whether or not lens
+                    aberration correction information is
+                    available</doc:summary>
+                    <doc:description>Code which indicates whether or not lens
+                    aberration correction information is
+                    available</doc:description>
+                    <doc:example>true</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="bandDescription" type="BandType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Band Description</doc:tooltip>
+                    <doc:summary>Description of the wavelength domain that the sensor operates
+                    in.</doc:summary>
+                    <doc:description>Description of the wavelength domain that the sensor operates
+                    in</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="BandType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Band Type</doc:tooltip>
+        <doc:summary>Complex type definition for band description.</doc:summary>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="sequenceIdentifier" type="res:NonEmptyStringType" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Sequence Identifier</doc:tooltip>
+            <doc:summary>Number that uniquely identifies instances of bands of
+            wavelengths on which a sensor operates.</doc:summary>
+            <doc:description>Number that uniquely identifies instances of bands
+            of wavelengths on which a sensor operates.</doc:description>
+            <doc:example>3</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="highWavelength" type="xs:float" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>High Wavelength</doc:tooltip>
+            <doc:summary>Highest wavelength that the sensor is capable of
+            collecting within a designated band in metres.</doc:summary>
+            <doc:description>Highest wavelength that the sensor is capable of
+            collecting within a designated band.</doc:description>
+            <doc:example>2.456</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="lowWaveLength" type="xs:float" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Low Wavelength</doc:tooltip>
+            <doc:summary>Lowest wavelength that the sensor is capable of
+            collecting within a designated band in metres.</doc:summary>
+            <doc:description>Lowest wavelength that the sensor is capable of
+            collecting within a designated band.</doc:description>
+            <doc:example>0.1234</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="waveLengthUnits" type="spref:lengthUnits" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Wave Length Units</doc:tooltip>
+            <doc:summary>Units in which the sensor wavelegths are
+            expressed.</doc:summary>
+            <doc:description>Units of measure for the wavelength at which the
+            sensor collected the data.</doc:description>
+            <doc:example>microns</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="peakResponse" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Peak Response</doc:tooltip>
+            <doc:summary>Wavelength at which the response is the highest.</doc:summary>
+            <doc:description/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="CellValueType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Cell Value Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Values"/>
+      <xs:enumeration value="Coded"/>
+      <xs:enumeration value="RGB"/>
+      <xs:enumeration value="Codes"/>
+      <xs:enumeration value="HIS"/>
+      <xs:enumeration value="HLS"/>
+      <xs:enumeration value="tekHVC"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ImagingConditionCode">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Imaging Condition Code Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="blurredimage"/>
+      <xs:enumeration value="cloud"/>
+      <xs:enumeration value="degradingObliquity"/>
+      <xs:enumeration value="fog"/>
+      <xs:enumeration value="heavySmokeorDust"/>
+      <xs:enumeration value="night"/>
+      <xs:enumeration value="rain"/>
+      <xs:enumeration value="semiDarkness"/>
+      <xs:enumeration value="shadow"/>
+      <xs:enumeration value="snow"/>
+      <xs:enumeration value="terrainMasking"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="rasterOriginType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Raster Origin Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Upper Left"/>
+      <xs:enumeration value="Lower Left"/>
+      <xs:enumeration value="Upper Right"/>
+      <xs:enumeration value="Lower Right"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CellGeometryType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Cell Geometry Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="pixel"/>
+      <xs:enumeration value="matrix"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DataQuality">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Data Quality Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="accuracyReport" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Accuracy Report</doc:tooltip>
+            <doc:summary>A qualitative statement about the accuracy of the data.</doc:summary>
+            <doc:description>A text statement of the data quality, included the means by which it was determined.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="quantitativeAccuracyReport" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Quantitative Accuracy Report</doc:tooltip>
+            <doc:summary>A quantitative assessment of the data quality.</doc:summary>
+            <doc:description>A quantitative assessment of the data quality expressed as a value and 
+            the method of its determination.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="quantitativeAccuracyValue" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Quantitative Accuracy Value</doc:tooltip>
+                  <doc:summary>The value resulting from the accuracy test.</doc:summary>
+                  <doc:description>The value resulting from the accuracy test. Typically, this will be expressed
+                  in units corresponding to those declared for the parameter being assessed.</doc:description>
+                  <doc:example>4.5</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="quantitativeAccuracyMethod" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Quantitative Accuracy Method</doc:tooltip>
+                  <doc:summary>The method used to calculate the accuracy value.</doc:summary>
+                  <doc:description>Identification and explanation of the method used to calculate the quantitative 
+                  accuracy assessment.</doc:description>
+                  <doc:example>Error expressed as root mean square of 5 control points. </doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-spatialReference.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-spatialReference.xsd
@@ -1,0 +1,2595 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1"
+    xmlns="eml://ecoinformatics.org/spatialReference-2.1.1"
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1"
+    targetNamespace="eml://ecoinformatics.org/spatialReference-2.1.1"
+    elementFormDefault="unqualified">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1"
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1"
+  schemaLocation="eml-resource.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-spatialReference.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.41 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-spatialReference</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              Schema for validating spatial referencing descriptions.
+            </title>
+            <para>
+             This module defines both projected and unprojected coordinate systems for
+             referencing the spatial coordinates of a dataset to the earth. The schema is based on
+             that used by Environmental Systems Research Inc (ESRI) for its .prj file format. EML provides a library of
+             pre-defined coordinate systems that may be referred to by name in the horizCoordSysName element. A
+             custom projection may be defined using this schema for any projection that does not appear in this
+             dictionary.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all spatial entities</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:complexType name="SpatialReferenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Spatial Reference Description</doc:tooltip>
+        <doc:summary>The system used to reference spatial locations to a
+        coordinate system</doc:summary>
+        <doc:description>A spatial reference description provides the
+        information for relating the positional information in a spatial
+        dataset to real-world locations. A description typically includes
+        identification of a reference datum, a spheroid definition, and
+        projection algorithm. It also provides any constants required by that
+        algorithm.</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element name="horizCoordSysName">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Horizonal Coordinate System Name</doc:tooltip>
+                <doc:summary>The name of a predefined coordinate system</doc:summary>
+                <doc:description>The name of a coordinate system for which a definition has been
+                provided in the eml-spatialReferenceDictionary.xsl file.</doc:description>
+                <doc:example>NAD_1927_StatePlane_Arizona_Central_FIPS_0202</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="GCS_Abidjan_1987"/>
+                <xs:enumeration value="GCS_Accra"/>
+                <xs:enumeration value="GCS_Adindan"/>
+                <xs:enumeration value="GCS_Afgooye"/>
+                <xs:enumeration value="GCS_Agadez"/>
+                <xs:enumeration value="GCS_Ain_el_Abd_1970"/>
+                <xs:enumeration value="GCS_Arc_1950"/>
+                <xs:enumeration value="GCS_Arc_1960"/>
+                <xs:enumeration value="GCS_Ayabelle"/>
+                <xs:enumeration value="GCS_Beduaram"/>
+                <xs:enumeration value="GCS_Bissau"/>
+                <xs:enumeration value="GCS_Camacupa"/>
+                <xs:enumeration value="GCS_Cape"/>
+                <xs:enumeration value="GCS_Carthage_Degree"/>
+                <xs:enumeration value="GCS_Carthage_Paris"/>
+                <xs:enumeration value="GCS_Carthage"/>
+                <xs:enumeration value="GCS_Conakry_1905"/>
+                <xs:enumeration value="GCS_Cote_d_Ivoire"/>
+                <xs:enumeration value="GCS_Dabola"/>
+                <xs:enumeration value="GCS_Douala"/>
+                <xs:enumeration value="GCS_Egypt_1907"/>
+                <xs:enumeration value="GCS_European_1950"/>
+                <xs:enumeration value="GCS_European_Libyan_Datum_1979"/>
+                <xs:enumeration value="GCS_Garoua"/>
+                <xs:enumeration value="GCS_Hartebeesthoek_1994"/>
+                <xs:enumeration value="GCS_Kuwait_Oil_Company"/>
+                <xs:enumeration value="GCS_KUDAMS"/>
+                <xs:enumeration value="GCS_Leigon"/>
+                <xs:enumeration value="GCS_Liberia_1964"/>
+                <xs:enumeration value="GCS_Locodjo_1965"/>
+                <xs:enumeration value="GCS_Lome"/>
+                <xs:enumeration value="GCS_Mporaloko"/>
+                <xs:enumeration value="GCS_Madzansua"/>
+                <xs:enumeration value="GCS_Mahe_1971"/>
+                <xs:enumeration value="GCS_Malongo_1987"/>
+                <xs:enumeration value="GCS_Manoca"/>
+                <xs:enumeration value="GCS_Massawa"/>
+                <xs:enumeration value="GCS_Merchich_Degree"/>
+                <xs:enumeration value="GCS_Merchich"/>
+                <xs:enumeration value="GCS_Mhast"/>
+                <xs:enumeration value="GCS_Minna"/>
+                <xs:enumeration value="GCS_Moznet"/>
+                <xs:enumeration value="GCS_Nahrwan_1967"/>
+                <xs:enumeration value="GCS_NGN"/>
+                <xs:enumeration value="GCS_Nord_Sahara_1959"/>
+                <xs:enumeration value="GCS_Observatario"/>
+                <xs:enumeration value="GCS_Oman"/>
+                <xs:enumeration value="GCS_Palestine_1923"/>
+                <xs:enumeration value="GCS_PDO_1993"/>
+                <xs:enumeration value="GCS_Point_58"/>
+                <xs:enumeration value="GCS_Pointe_Noire"/>
+                <xs:enumeration value="GCS_Qatar_1948"/>
+                <xs:enumeration value="GCS_Qatar"/>
+                <xs:enumeration value="GCS_Schwarzeck"/>
+                <xs:enumeration value="GCS_Sierra_Leone_1924"/>
+                <xs:enumeration value="GCS_Sierra_Leone_1960"/>
+                <xs:enumeration value="GCS_Sierra_Leone_1968"/>
+                <xs:enumeration value="GCS_South_Yemen"/>
+                <xs:enumeration value="GCS_Sudan"/>
+                <xs:enumeration value="GCS_Tananarive_1925_Paris"/>
+                <xs:enumeration value="GCS_Tananarive_1925"/>
+                <xs:enumeration value="GCS_Tete"/>
+                <xs:enumeration value="GCS_Trucial_Coast_1948"/>
+                <xs:enumeration value="GCS_Voirol_1875_Degree"/>
+                <xs:enumeration value="GCS_Voirol_1875_Paris"/>
+                <xs:enumeration value="GCS_Voirol_1875"/>
+                <xs:enumeration value="GCS_Voirol_Unifie_1960_Degree"/>
+                <xs:enumeration value="GCS_Voirol_Unifie_1960_Paris"/>
+                <xs:enumeration value="GCS_Voirol_Unifie_1960"/>
+                <xs:enumeration value="GCS_Yemen_NGN_1996"/>
+                <xs:enumeration value="GCS_Yoff"/>
+                <xs:enumeration value="GCS_Camp_Area"/>
+                <xs:enumeration value="GCS_Deception_Island"/>
+                <xs:enumeration value="GCS_Ain_el_Abd_1970"/>
+                <xs:enumeration value="GCS_Batavia_Jakarta"/>
+                <xs:enumeration value="GCS_Batavia"/>
+                <xs:enumeration value="GCS_Beijing_1954"/>
+                <xs:enumeration value="GCS_Bukit_Rimpah"/>
+                <xs:enumeration value="GCS_Deir_ez_Zor"/>
+                <xs:enumeration value="GCS_European_1950_ED77"/>
+                <xs:enumeration value="GCS_European_1950"/>
+                <xs:enumeration value="GCS_Everest_def_1962"/>
+                <xs:enumeration value="GCS_Everest_def_1967"/>
+                <xs:enumeration value="GCS_Everest_def_1975"/>
+                <xs:enumeration value="GCS_Everest_Bangladesh"/>
+                <xs:enumeration value="GCS_Everest_India_Nepal"/>
+                <xs:enumeration value="GCS_Everest_1830"/>
+                <xs:enumeration value="GCS_Everest_Modified"/>
+                <xs:enumeration value="GCS_Fahud"/>
+                <xs:enumeration value="GCS_FD_1958"/>
+                <xs:enumeration value="GCS_Gandajika_1970"/>
+                <xs:enumeration value="GCS_Gunung_Segara"/>
+                <xs:enumeration value="GCS_Hanoi_1972"/>
+                <xs:enumeration value="GCS_Herat_North"/>
+                <xs:enumeration value="GCS_Hong_Kong_1963"/>
+                <xs:enumeration value="GCS_Hong_Kong_1980"/>
+                <xs:enumeration value="GCS_Hu_Tzu_Shan"/>
+                <xs:enumeration value="GCS_Indian_1954"/>
+                <xs:enumeration value="GCS_Indian_1960"/>
+                <xs:enumeration value="GCS_Indian_1975"/>
+                <xs:enumeration value="GCS_Indonesian_1974"/>
+                <xs:enumeration value="GCS_Israel"/>
+                <xs:enumeration value="GCS_JGD_2000"/>
+                <xs:enumeration value="GCS_Kalianpur_1880"/>
+                <xs:enumeration value="GCS_Kalianpur_1937"/>
+                <xs:enumeration value="GCS_Kalianpur_1962"/>
+                <xs:enumeration value="GCS_Kalianpur_1975"/>
+                <xs:enumeration value="GCS_Kandawala"/>
+                <xs:enumeration value="GCS_Kertau"/>
+                <xs:enumeration value="GCS_Korean_Datum_1985"/>
+                <xs:enumeration value="GCS_Korean_Datum_1995"/>
+                <xs:enumeration value="GCS_Kuwait_Oil_Company"/>
+                <xs:enumeration value="GCS_KUDAMS"/>
+                <xs:enumeration value="GCS_Luzon_1911"/>
+                <xs:enumeration value="GCS_Makassar_Jakarta"/>
+                <xs:enumeration value="GCS_Makassar"/>
+                <xs:enumeration value="GCS_Nahrwan_1967"/>
+                <xs:enumeration value="GCS_NGN"/>
+                <xs:enumeration value="GCS_Oman"/>
+                <xs:enumeration value="GCS_Padang_1884_Jakarta"/>
+                <xs:enumeration value="GCS_Padang_1884"/>
+                <xs:enumeration value="GCS_Palestine_1923"/>
+                <xs:enumeration value="GCS_Pulkovo_1942"/>
+                <xs:enumeration value="GCS_Pulkovo_1995"/>
+                <xs:enumeration value="GCS_Qatar_1948"/>
+                <xs:enumeration value="GCS_Qatar"/>
+                <xs:enumeration value="GCS_Rassadiran"/>
+                <xs:enumeration value="GCS_Samboja"/>
+                <xs:enumeration value="GCS_Segora"/>
+                <xs:enumeration value="GCS_Serindung"/>
+                <xs:enumeration value="GCS_South_Asia_Singapore"/>
+                <xs:enumeration value="GCS_Timbalai_1948"/>
+                <xs:enumeration value="GCS_Tokyo"/>
+                <xs:enumeration value="GCS_Trucial_Coast_1948"/>
+                <xs:enumeration value="GCS_Australian_1966"/>
+                <xs:enumeration value="GCS_Australian_1984"/>
+                <xs:enumeration value="GCS_GDA_1994"/>
+                <xs:enumeration value="GCS_New_Zealand_1949"/>
+                <xs:enumeration value="GCS_NZGD_2000"/>
+                <xs:enumeration value="GCS_Amersfoort"/>
+                <xs:enumeration value="GCS_ATF_Paris"/>
+                <xs:enumeration value="GCS_Belge_1950_Brussels"/>
+                <xs:enumeration value="GCS_Belge_1972"/>
+                <xs:enumeration value="GCS_Bern_1898_Bern"/>
+                <xs:enumeration value="GCS_Bern_1898"/>
+                <xs:enumeration value="GCS_Bern_1938"/>
+                <xs:enumeration value="GCS_CH1903+"/>
+                <xs:enumeration value="GCS_CH1903"/>
+                <xs:enumeration value="GCS_Datum_73"/>
+                <xs:enumeration value="GCS_Datum_Lisboa_Bessel"/>
+                <xs:enumeration value="GCS_Datum_Lisboa_Bessel"/>
+                <xs:enumeration value="GCS_Dealul_Piscului_1933"/>
+                <xs:enumeration value="GCS_Dealul_Piscului_1970"/>
+                <xs:enumeration value="GCS_Deutsche_Hauptdreiecksnetz"/>
+                <xs:enumeration value="GCS_Estonia_1937"/>
+                <xs:enumeration value="GCS_Estonia_1992"/>
+                <xs:enumeration value="GCS_ETRF_1989"/>
+                <xs:enumeration value="GCS_European_1979"/>
+                <xs:enumeration value="GCS_European_1950"/>
+                <xs:enumeration value="GCS_European_1987"/>
+                <xs:enumeration value="GCS_Greek_Athens"/>
+                <xs:enumeration value="GCS_Greek"/>
+                <xs:enumeration value="GCS_Hermannskogel"/>
+                <xs:enumeration value="GCS_Hjorsey_1955"/>
+                <xs:enumeration value="GCS_Hungarian_1972"/>
+                <xs:enumeration value="GCS_IRENET95"/>
+                <xs:enumeration value="GCS_KKJ"/>
+                <xs:enumeration value="GCS_Lisbon_Lisbon"/>
+                <xs:enumeration value="GCS_Lisbon"/>
+                <xs:enumeration value="GCS_LKS_1994"/>
+                <xs:enumeration value="GCS_Madrid_1870_Madrid"/>
+                <xs:enumeration value="GCS_MGI_Ferro"/>
+                <xs:enumeration value="GCS_MGI"/>
+                <xs:enumeration value="GCS_Monte_Mario_Rome"/>
+                <xs:enumeration value="GCS_Monte_Mario"/>
+                <xs:enumeration value="GCS_NGO_1948_Oslo"/>
+                <xs:enumeration value="GCS_NGO_1948"/>
+                <xs:enumeration value="GCS_Nord_de_Guerre_Paris"/>
+                <xs:enumeration value="GCS_NTF"/>
+                <xs:enumeration value="GCS_NTF_Paris"/>
+                <xs:enumeration value="GCS_OS_SN_1980"/>
+                <xs:enumeration value="GCS_OSGB_1936"/>
+                <xs:enumeration value="GCS_OSGB_1970_SN"/>
+                <xs:enumeration value="GCS_Pulkovo_1942"/>
+                <xs:enumeration value="GCS_Pulkovo_1995"/>
+                <xs:enumeration value="GCS_Qornoq"/>
+                <xs:enumeration value="GCS_Belge_1950"/>
+                <xs:enumeration value="GCS_Belge_1972"/>
+                <xs:enumeration value="GCS_RGF_1993"/>
+                <xs:enumeration value="GCS_RT_1990"/>
+                <xs:enumeration value="GCS_RT38_Stockholm"/>
+                <xs:enumeration value="GCS_RT38"/>
+                <xs:enumeration value="GCS_S42_Hungary"/>
+                <xs:enumeration value="GCS_S_JTSK"/>
+                <xs:enumeration value="GCS_Swiss_TRF_1995"/>
+                <xs:enumeration value="GCS_TM65"/>
+                <xs:enumeration value="GCS_TM75"/>
+                <xs:enumeration value="GCS_Alaskan_Islands"/>
+                <xs:enumeration value="GCS_American_Samoa_1962"/>
+                <xs:enumeration value="GCS_ATS_1977"/>
+                <xs:enumeration value="GCS_Barbados"/>
+                <xs:enumeration value="GCS_Bermuda_1957"/>
+                <xs:enumeration value="GCS_Cape_Canaveral"/>
+                <xs:enumeration value="GCS_Guam_1963"/>
+                <xs:enumeration value="GCS_Jamaica_1875"/>
+                <xs:enumeration value="GCS_Jamaica_1969"/>
+                <xs:enumeration value="GCS_NAD_1927_CGQ77"/>
+                <xs:enumeration value="GCS_NAD_1927_Definition_1976"/>
+                <xs:enumeration value="GCS_North_American_Michigan"/>
+                <xs:enumeration value="GCS_North_American_1983_CSRS98"/>
+                <xs:enumeration value="GCS_North_American_1983_HARN"/>
+                <xs:enumeration value="GCS_North_American_1927"/>
+                <xs:enumeration value="GCS_North_American_1983"/>
+                <xs:enumeration value="GCS_Old_Hawaiian"/>
+                <xs:enumeration value="GCS_Puerto_Rico"/>
+                <xs:enumeration value="GCS_Qornoq"/>
+                <xs:enumeration value="GCS_St_George_Island"/>
+                <xs:enumeration value="GCS_St_Lawrence_Island"/>
+                <xs:enumeration value="GCS_St_Paul_Island"/>
+                <xs:enumeration value="GCS_Alaskan_Islands"/>
+                <xs:enumeration value="GCS_American_Samoa_1962"/>
+                <xs:enumeration value="GCS_Anguilla_1957"/>
+                <xs:enumeration value="GCS_Anna_1_1965"/>
+                <xs:enumeration value="GCS_Antigua_1943"/>
+                <xs:enumeration value="GCS_Ascension_Island_1958"/>
+                <xs:enumeration value="GCS_Beacon_E_1945"/>
+                <xs:enumeration value="GCS_DOS_71_4"/>
+                <xs:enumeration value="GCS_Astro_1952"/>
+                <xs:enumeration value="GCS_Bab_South"/>
+                <xs:enumeration value="GCS_Barbados_1938"/>
+                <xs:enumeration value="GCS_Barbados"/>
+                <xs:enumeration value="GCS_Bellevue_IGN"/>
+                <xs:enumeration value="GCS_Bermuda_1957"/>
+                <xs:enumeration value="GCS_Canton_1966"/>
+                <xs:enumeration value="GCS_Chatham_Island_1971"/>
+                <xs:enumeration value="GCS_Dominica_1945"/>
+                <xs:enumeration value="GCS_DOS_1968"/>
+                <xs:enumeration value="GCS_Easter_Island_1967"/>
+                <xs:enumeration value="GCS_Fort_Thomas_1955"/>
+                <xs:enumeration value="GCS_Gan_1970"/>
+                <xs:enumeration value="GCS_Graciosa_Base_SW_1948"/>
+                <xs:enumeration value="GCS_Grenada_1953"/>
+                <xs:enumeration value="GCS_Guam_1963"/>
+                <xs:enumeration value="GCS_GUX_1"/>
+                <xs:enumeration value="GCS_Hjorsey_1955"/>
+                <xs:enumeration value="GCS_ISTS_061_1968"/>
+                <xs:enumeration value="GCS_ISTS_073_1969"/>
+                <xs:enumeration value="GCS_Jamaica_1875"/>
+                <xs:enumeration value="GCS_Jamaica_1969"/>
+                <xs:enumeration value="GCS_Johnston_Island_1961"/>
+                <xs:enumeration value="GCS_Kerguelen_Island_1949"/>
+                <xs:enumeration value="GCS_Kusaie_1951"/>
+                <xs:enumeration value="GCS_LC5_1961"/>
+                <xs:enumeration value="GCS_Mahe_1971"/>
+                <xs:enumeration value="GCS_Majuro"/>
+                <xs:enumeration value="GCS_Midway_1961"/>
+                <xs:enumeration value="GCS_Montserrat_1958"/>
+                <xs:enumeration value="GCS_Observ_Meteorologico_1939"/>
+                <xs:enumeration value="GCS_Old_Hawaiian"/>
+                <xs:enumeration value="GCS_Pico_de_Las_Nieves"/>
+                <xs:enumeration value="GCS_Pitcairn_1967"/>
+                <xs:enumeration value="GCS_Pohnpei"/>
+                <xs:enumeration value="GCS_Porto_Santo_1936"/>
+                <xs:enumeration value="GCS_Puerto_Rico"/>
+                <xs:enumeration value="GCS_Reunion"/>
+                <xs:enumeration value="GCS_Santo_DOS_1965"/>
+                <xs:enumeration value="GCS_Sao_Braz"/>
+                <xs:enumeration value="GCS_Sapper_Hill_1943"/>
+                <xs:enumeration value="GCS_Selvagem_Grande_1938"/>
+                <xs:enumeration value="GCS_St_Kitts_1955"/>
+                <xs:enumeration value="GCS_St_Lucia_1955"/>
+                <xs:enumeration value="GCS_St_Vincent_1945"/>
+                <xs:enumeration value="GCS_Tern_Island_1961"/>
+                <xs:enumeration value="GCS_Tristan_1968"/>
+                <xs:enumeration value="GCS_Viti_Levu_1916"/>
+                <xs:enumeration value="GCS_Wake_Island_1952"/>
+                <xs:enumeration value="GCS_Wake_Eniwetok_1960"/>
+                <xs:enumeration value="GCS_Aratu"/>
+                <xs:enumeration value="GCS_Bogota_Bogota"/>
+                <xs:enumeration value="GCS_Bogota"/>
+                <xs:enumeration value="GCS_Campo_Inchauspe"/>
+                <xs:enumeration value="GCS_Chos_Malal_1914"/>
+                <xs:enumeration value="GCS_Chua"/>
+                <xs:enumeration value="GCS_Corrego_Alegre"/>
+                <xs:enumeration value="GCS_Guyane_Francaise"/>
+                <xs:enumeration value="GCS_Hito_XVIII_1963"/>
+                <xs:enumeration value="GCS_La_Canoa"/>
+                <xs:enumeration value="GCS_Lake"/>
+                <xs:enumeration value="GCS_Loma_Quintana"/>
+                <xs:enumeration value="GCS_Mount_Dillon"/>
+                <xs:enumeration value="GCS_Naparima_1955"/>
+                <xs:enumeration value="GCS_Naparima_1972"/>
+                <xs:enumeration value="GCS_Pampa_del_Castillo"/>
+                <xs:enumeration value="GCS_POSGAR"/>
+                <xs:enumeration value="GCS_REGVEN"/>
+                <xs:enumeration value="GCS_Sapper_Hill_1943"/>
+                <xs:enumeration value="GCS_SIRGAS"/>
+                <xs:enumeration value="GCS_South_American_1969"/>
+                <xs:enumeration value="GCS_Trinidad_1903"/>
+                <xs:enumeration value="GCS_Yacare"/>
+                <xs:enumeration value="GCS_Zanderij"/>
+                <xs:enumeration value="GCS_Airy_1830"/>
+                <xs:enumeration value="GCS_Airy_Modified"/>
+                <xs:enumeration value="GCS_Australian"/>
+                <xs:enumeration value="GCS_Sphere_ARC_INFO"/>
+                <xs:enumeration value="GCS_Sphere"/>
+                <xs:enumeration value="GCS_ATS_1977"/>
+                <xs:enumeration value="GCS_Bessel_1841"/>
+                <xs:enumeration value="GCS_Bessel_Modified"/>
+                <xs:enumeration value="GCS_Bessel_Namibia"/>
+                <xs:enumeration value="GCS_Clarke_1858"/>
+                <xs:enumeration value="GCS_Clarke_1866_Michigan"/>
+                <xs:enumeration value="GCS_Clarke_1866"/>
+                <xs:enumeration value="GCS_Clarke_1880_Arc"/>
+                <xs:enumeration value="GCS_Clarke_1880_Benoit"/>
+                <xs:enumeration value="GCS_Clarke_1880_IGN"/>
+                <xs:enumeration value="GCS_Clarke_1880_RGS"/>
+                <xs:enumeration value="GCS_Clarke_1880_SGA"/>
+                <xs:enumeration value="GCS_Clarke_1880"/>
+                <xs:enumeration value="GCS_Everest_def_1967"/>
+                <xs:enumeration value="GCS_Everest_def_1975"/>
+                <xs:enumeration value="GCS_Everest_1830"/>
+                <xs:enumeration value="GCS_Everest_Modified_1969"/>
+                <xs:enumeration value="GCS_Everest_Modified"/>
+                <xs:enumeration value="GCS_Fischer_1960"/>
+                <xs:enumeration value="GCS_Fischer_1968"/>
+                <xs:enumeration value="GCS_Fischer_Modified"/>
+                <xs:enumeration value="GCS_GEM_10C"/>
+                <xs:enumeration value="GCS_GRS_1967"/>
+                <xs:enumeration value="GCS_GRS_1980"/>
+                <xs:enumeration value="GCS_Helmert_1906"/>
+                <xs:enumeration value="GCS_Hough_1960"/>
+                <xs:enumeration value="GCS_Indonesian"/>
+                <xs:enumeration value="GCS_International_1924"/>
+                <xs:enumeration value="GCS_International_1967"/>
+                <xs:enumeration value="GCS_Krasovsky_1940"/>
+                <xs:enumeration value="GCS_OSU_86F"/>
+                <xs:enumeration value="GCS_OSU_91A"/>
+                <xs:enumeration value="GCS_Plessis_1817"/>
+                <xs:enumeration value="GCS_Struve_1860"/>
+                <xs:enumeration value="GCS_NWL_9D"/>
+                <xs:enumeration value="GCS_Walbeck"/>
+                <xs:enumeration value="GCS_War_Office"/>
+                <xs:enumeration value="GCS_WGS_1966"/>
+                <xs:enumeration value="GCS_NSWC_9Z_2"/>
+                <xs:enumeration value="GCS_WGS_1966"/>
+                <xs:enumeration value="GCS_WGS_1972_BE"/>
+                <xs:enumeration value="GCS_WGS_1972"/>
+                <xs:enumeration value="GCS_WGS_1984"/>
+                <xs:enumeration value="Africa_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="Africa_Equidistant_Conic"/>
+                <xs:enumeration value="Africa_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Africa_Sinusoidal"/>
+                <xs:enumeration value="Asia_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Asia_North_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="Asia_North_Equidistant_Conic"/>
+                <xs:enumeration value="Asia_North_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Asia_South_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="Asia_South_Equidistant_Conic"/>
+                <xs:enumeration value="Asia_South_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Europe_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="Europe_Equidistant_Conic"/>
+                <xs:enumeration value="Europe_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Alaska_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="Canada_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="Canada_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Hawaii_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="North_America_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="North_America_Equidistant_Conic"/>
+                <xs:enumeration value="North_America_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="USA_Contiguous_Albers_Equal_Area_Conic_USGS_version"/>
+                <xs:enumeration value="USA_Contiguous_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="USA_Contiguous_Equidistant_Conic"/>
+                <xs:enumeration value="USA_Contiguous_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="South_America_Albers_Equal_Area_Conic"/>
+                <xs:enumeration value="South_America_Equidistant_Conic"/>
+                <xs:enumeration value="South_America_Lambert_Conformal_Conic"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_13"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_13N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_14"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_14N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_15"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_15N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_16"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_16N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_17"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_17N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_18"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_18N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_19"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_19N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_20"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_20N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_21"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_21N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_22"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_22N"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_23"/>
+                <xs:enumeration value="Beijing_1954_GK_Zone_23N"/>
+                <xs:enumeration value="Hanoi_1972_GK_Zone_18"/>
+                <xs:enumeration value="Hanoi_1972_GK_Zone_19"/>
+                <xs:enumeration value="South_Yemen_GK_Zone_8"/>
+                <xs:enumeration value="South_Yemen_GK_Zone_9"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_10"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_10N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_11"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_11N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_12"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_12N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_13"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_13N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_14"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_14N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_15"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_15N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_16"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_16N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_17"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_17N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_18"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_18N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_19"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_19N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_2"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_20"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_20N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_21"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_21N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_22"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_22N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_23"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_23N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_24"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_24N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_25"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_25N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_26"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_26N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_27"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_27N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_28"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_28N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_29"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_29N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_2N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_3"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_30"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_30N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_31"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_31N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_32"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_32N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_3N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_4"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_4N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_5"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_5N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_6"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_6N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_7"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_7N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_8"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_8N"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_9"/>
+                <xs:enumeration value="Pulkovo_1942_GK_Zone_9N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_10"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_10N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_11"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_11N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_12"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_12N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_13"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_13N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_14"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_14N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_15"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_15N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_16"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_16N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_17"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_17N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_18"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_18N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_19"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_19N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_2"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_20"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_20N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_21"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_21N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_22"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_22N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_23"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_23N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_24"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_24N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_25"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_25N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_26"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_26N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_27"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_27N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_28"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_28N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_29"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_29N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_2N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_3"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_30"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_30N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_31"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_31N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_32"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_32N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_3N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_4"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_4N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_5"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_5N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_6"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_6N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_7"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_7N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_8"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_8N"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_9"/>
+                <xs:enumeration value="Pulkovo_1995_GK_Zone_9N"/>
+                <xs:enumeration value="Abidjan_1987_TM_5_NW"/>
+                <xs:enumeration value="Accra_Ghana_Grid"/>
+                <xs:enumeration value="Accra_TM_1_NW"/>
+                <xs:enumeration value="Samoa_1962_Samoa_Lambert"/>
+                <xs:enumeration value="Anguilla_1957_British_West_Indies_Grid"/>
+                <xs:enumeration value="Antigua_1943_British_West_Indies_Grid"/>
+                <xs:enumeration value="Argentina_Zone_1"/>
+                <xs:enumeration value="Argentina_Zone_2"/>
+                <xs:enumeration value="Argentina_Zone_3"/>
+                <xs:enumeration value="Argentina_Zone_4"/>
+                <xs:enumeration value="Argentina_Zone_5"/>
+                <xs:enumeration value="Argentina_Zone_6"/>
+                <xs:enumeration value="Argentina_Zone_7"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_48"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_49"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_50"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_51"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_52"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_53"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_54"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_55"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_56"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_57"/>
+                <xs:enumeration value="AGD_1966_AMG_Zone_58"/>
+                <xs:enumeration value="AGD_1966_VICGRID"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_48"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_49"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_50"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_51"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_52"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_53"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_54"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_55"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_56"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_57"/>
+                <xs:enumeration value="AGD_1984_AMG_Zone_58"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_48"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_49"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_50"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_51"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_52"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_53"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_54"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_55"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_56"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_57"/>
+                <xs:enumeration value="GDA_1994_MGA_Zone_58"/>
+                <xs:enumeration value="GDA_1994_South_Australia_Lambert"/>
+                <xs:enumeration value="GDA_1994_VICGRID94"/>
+                <xs:enumeration value="Austria_Central_Zone"/>
+                <xs:enumeration value="Austria_East_Zone"/>
+                <xs:enumeration value="Austria_West_Zone"/>
+                <xs:enumeration value="Bahrain_State_Grid"/>
+                <xs:enumeration value="Barbados_1938_Barbados_Grid"/>
+                <xs:enumeration value="Barbados_1938_British_West_Indies_Grid"/>
+                <xs:enumeration value="Belge_Lambert_1950"/>
+                <xs:enumeration value="Belge_Lambert_1972"/>
+                <xs:enumeration value="Bern_1898_Bern_LV03C"/>
+                <xs:enumeration value="British_National_Grid"/>
+                <xs:enumeration value="Camacupa_TM_11_30_SE"/>
+                <xs:enumeration value="Camacupa_TM_12_SE"/>
+                <xs:enumeration value="ATS_1977_MTM_4_Nova_Scotia"/>
+                <xs:enumeration value="ATS_1977_MTM_5_Nova_Scotia"/>
+                <xs:enumeration value="ATS_1977_New_Brunswick_Stereographic"/>
+                <xs:enumeration value="NAD_1927_10TM_AEP_Forest"/>
+                <xs:enumeration value="NAD_1927_10TM_AEP_Resource"/>
+                <xs:enumeration value="NAD_1927_3TM_111"/>
+                <xs:enumeration value="NAD_1927_3TM_114"/>
+                <xs:enumeration value="NAD_1927_3TM_117"/>
+                <xs:enumeration value="NAD_1927_3TM_120"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_10_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_2_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_3_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_4_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_5_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_6_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_7_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_8_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_MTM_9_SCoPQ"/>
+                <xs:enumeration value="NAD_1927_CGQ77_Quebec_Lambert"/>
+                <xs:enumeration value="NAD_1927_CGQ77_UTM_Zone_17N"/>
+                <xs:enumeration value="NAD_1927_CGQ77_UTM_Zone_18N"/>
+                <xs:enumeration value="NAD_1927_CGQ77_UTM_Zone_19N"/>
+                <xs:enumeration value="NAD_1927_CGQ77_UTM_Zone_20N"/>
+                <xs:enumeration value="NAD_1927_CGQ77_UTM_Zone_21N"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_10"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_11"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_12"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_13"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_14"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_15"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_16"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_17"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_8"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_MTM_9"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_UTM_Zone_15N"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_UTM_Zone_16N"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_UTM_Zone_17N"/>
+                <xs:enumeration value="NAD_1927_DEF_1976_UTM_Zone_18N"/>
+                <xs:enumeration value="NAD_1927_MTM_1"/>
+                <xs:enumeration value="NAD_1927_MTM_2"/>
+                <xs:enumeration value="NAD_1927_MTM_3"/>
+                <xs:enumeration value="NAD_1927_MTM_4"/>
+                <xs:enumeration value="NAD_1927_MTM_5"/>
+                <xs:enumeration value="NAD_1927_MTM_6"/>
+                <xs:enumeration value="NAD_1927_Quebec_Lambert"/>
+                <xs:enumeration value="NAD_1983_10TM_AEP_Forest"/>
+                <xs:enumeration value="NAD_1983_10TM_AEP_Resource"/>
+                <xs:enumeration value="NAD_1983_3TM_111"/>
+                <xs:enumeration value="NAD_1983_3TM_114"/>
+                <xs:enumeration value="NAD_1983_3TM_117"/>
+                <xs:enumeration value="NAD_1983_3TM_120"/>
+                <xs:enumeration value="NAD_1983_BC_Environment_Albers"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_10"/>
+                <xs:enumeration value="NAD_1983_CSRS98_MTM_2_SCoPQ"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_3"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_4"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_5"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_6"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_7"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_8"/>
+                <xs:enumeration value="NAD_1983_CRS98_MTM_9"/>
+                <xs:enumeration value="NAD_1983_CSRS98_New_Brunswick_Stereographic"/>
+                <xs:enumeration value="NAD_1983_CSRS98_Prince_Edward_Island"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_21N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_11N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_12N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_13N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_17N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_18N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_19N"/>
+                <xs:enumeration value="NAD_1983_CSRS98_UTM_Zone_20N"/>
+                <xs:enumeration value="NAD_1983_MTM_1"/>
+                <xs:enumeration value="NAD_1983_MTM_10"/>
+                <xs:enumeration value="NAD_1983_MTM_11"/>
+                <xs:enumeration value="NAD_1983_MTM_12"/>
+                <xs:enumeration value="NAD_1983_MTM_13"/>
+                <xs:enumeration value="NAD_1983_MTM_14"/>
+                <xs:enumeration value="NAD_1983_MTM_15"/>
+                <xs:enumeration value="NAD_1983_MTM_16"/>
+                <xs:enumeration value="NAD_1983_MTM_17"/>
+                <xs:enumeration value="NAD_1983_MTM_2_SCoPQ"/>
+                <xs:enumeration value="NAD_1983_MTM_2"/>
+                <xs:enumeration value="NAD_1983_MTM_3"/>
+                <xs:enumeration value="NAD_1983_MTM_4"/>
+                <xs:enumeration value="NAD_1983_MTM_5"/>
+                <xs:enumeration value="NAD_1983_MTM_6"/>
+                <xs:enumeration value="NAD_1983_MTM_7"/>
+                <xs:enumeration value="NAD_1983_MTM_8"/>
+                <xs:enumeration value="NAD_1983_MTM_9"/>
+                <xs:enumeration value="NAD_1983_Quebec_Lambert"/>
+                <xs:enumeration value="Prince_Edward_Island_Stereographic"/>
+                <xs:enumeration value="Carthage_TM_11_NE"/>
+                <xs:enumeration value="Centre_France"/>
+                <xs:enumeration value="CH1903_LV03"/>
+                <xs:enumeration value="CH1903+_LV95"/>
+                <xs:enumeration value="Chos_Malal_1914_Argentina_2"/>
+                <xs:enumeration value="Colombia_Bogota_Zone"/>
+                <xs:enumeration value="Colombia_East_Central_Zone"/>
+                <xs:enumeration value="Colombia_East_Zone"/>
+                <xs:enumeration value="Colombia_West_Zone"/>
+                <xs:enumeration value="Corse"/>
+                <xs:enumeration value="Datum_73_Hayford_Gauss_IGeoE"/>
+                <xs:enumeration value="Datum_73_Hayford_Gauss_IPCC"/>
+                <xs:enumeration value="Deir_ez_Zor_Levant_Stereographic"/>
+                <xs:enumeration value="Deir_ez_Zor_Levant_Zone"/>
+                <xs:enumeration value="Deir_ez_Zor_Syria_Lambert"/>
+                <xs:enumeration value="DHDN_3_Degree_Gauss_Zone_1"/>
+                <xs:enumeration value="DHDN_3_Degree_Gauss_Zone_2"/>
+                <xs:enumeration value="DHDN_3_Degree_Gauss_Zone_3"/>
+                <xs:enumeration value="DHDN_3_Degree_Gauss_Zone_4"/>
+                <xs:enumeration value="DHDN_3_Degree_Gauss_Zone_5"/>
+                <xs:enumeration value="Dominica_1945_British_West_Indies_Grid"/>
+                <xs:enumeration value="ED_1950_TM_0_N"/>
+                <xs:enumeration value="ED_1950_TM_5_NE"/>
+                <xs:enumeration value="Egypt_Blue_Belt"/>
+                <xs:enumeration value="Egypt_Extended_Purple_Belt"/>
+                <xs:enumeration value="Egypt_Purple_Belt"/>
+                <xs:enumeration value="Egypt_Red_Belt"/>
+                <xs:enumeration value="ELD_1979_Libya_10"/>
+                <xs:enumeration value="ELD_1979_Libya_11"/>
+                <xs:enumeration value="ELD_1979_Libya_12"/>
+                <xs:enumeration value="ELD_1979_Libya_13"/>
+                <xs:enumeration value="ELD_1979_Libya_5"/>
+                <xs:enumeration value="ELD_1979_Libya_6"/>
+                <xs:enumeration value="ELD_1979_Libya_7"/>
+                <xs:enumeration value="ELD_1979_Libya_8"/>
+                <xs:enumeration value="ELD_1979_Libya_9"/>
+                <xs:enumeration value="ELD_1979_TM_12_NE"/>
+                <xs:enumeration value="Estonian_Coordinate_System_of_1992"/>
+                <xs:enumeration value="ETRF_1989_TM_Baltic_1993"/>
+                <xs:enumeration value="FD_1958_Iraq"/>
+                <xs:enumeration value="Finland_Zone_1"/>
+                <xs:enumeration value="Finland_Zone_2"/>
+                <xs:enumeration value="Finland_Zone_3"/>
+                <xs:enumeration value="Finland_Zone_4"/>
+                <xs:enumeration value="France_I"/>
+                <xs:enumeration value="France_II"/>
+                <xs:enumeration value="France_III"/>
+                <xs:enumeration value="France_IV"/>
+                <xs:enumeration value="Germany_Zone_1"/>
+                <xs:enumeration value="Germany_Zone_2"/>
+                <xs:enumeration value="Germany_Zone_3"/>
+                <xs:enumeration value="Germany_Zone_4"/>
+                <xs:enumeration value="Germany_Zone_5"/>
+                <xs:enumeration value="Ghana_Metre_Grid"/>
+                <xs:enumeration value="Greek_Grid"/>
+                <xs:enumeration value="Grenada_1953_British_West_Indies_Grid"/>
+                <xs:enumeration value="Hanoi_1972_GK_106_NE"/>
+                <xs:enumeration value="HD_1972_Egyseges_Orszagos_Vetuleti"/>
+                <xs:enumeration value="Hito_XVIII_1963_Argentina_2"/>
+                <xs:enumeration value="Hong_Kong_1980_Grid"/>
+                <xs:enumeration value="Indian_1960_TM_106NE"/>
+                <xs:enumeration value="Kalianpur_1880_India_Zone_0"/>
+                <xs:enumeration value="Kalianpur_1880_India_Zone_I"/>
+                <xs:enumeration value="Kalianpur_1880_India_Zone_IIa"/>
+                <xs:enumeration value="Kalianpur_1880_India_Zone_IIb"/>
+                <xs:enumeration value="Kalianpur_1880_India_Zone_III"/>
+                <xs:enumeration value="Kalianpur_1880_India_Zone_IV"/>
+                <xs:enumeration value="Kalianpur_1937_India_Zone_IIb"/>
+                <xs:enumeration value="Kalianpur_1937_UTM_Zone_45N"/>
+                <xs:enumeration value="Kalianpur_1937_UTM_Zone_46N"/>
+                <xs:enumeration value="Kalianpur_1962_India_Zone_I"/>
+                <xs:enumeration value="Kalianpur_1962_India_Zone_IIa"/>
+                <xs:enumeration value="Kalianpur_1962_UTM_Zone_41N"/>
+                <xs:enumeration value="Kalianpur_1962_UTM_Zone_42N"/>
+                <xs:enumeration value="Kalianpur_1962_UTM_Zone_43N"/>
+                <xs:enumeration value="Kalianpur_1975_India_Zone_I"/>
+                <xs:enumeration value="Kalianpur_1975_India_Zone_IIa"/>
+                <xs:enumeration value="Kalianpur_1975_India_Zone_IIb"/>
+                <xs:enumeration value="Kalianpur_1975_India_Zone_III"/>
+                <xs:enumeration value="Kalianpur_1975_India_Zone_IV"/>
+                <xs:enumeration value="Kalianpur_1975_UTM_Zone_42N"/>
+                <xs:enumeration value="Kalianpur_1975_UTM_Zone_43N"/>
+                <xs:enumeration value="Kalianpur_1975_UTM_Zone_44N"/>
+                <xs:enumeration value="Kalianpur_1975_UTM_Zone_45N"/>
+                <xs:enumeration value="Kalianpur_1975_UTM_Zone_46N"/>
+                <xs:enumeration value="Kalianpur_1975_UTM_Zone_47N"/>
+                <xs:enumeration value="IRENET95_IRISH_Transverse_Mercator"/>
+                <xs:enumeration value="Irish_National_Grid"/>
+                <xs:enumeration value="Israel_TM_Grid"/>
+                <xs:enumeration value="Jamaica_1875_Old_Grid"/>
+                <xs:enumeration value="Jamaica_Grid"/>
+                <xs:enumeration value="Japan_Zone_1"/>
+                <xs:enumeration value="Japan_Zone_10"/>
+                <xs:enumeration value="Japan_Zone_11"/>
+                <xs:enumeration value="Japan_Zone_12"/>
+                <xs:enumeration value="Japan_Zone_13"/>
+                <xs:enumeration value="Japan_Zone_14"/>
+                <xs:enumeration value="Japan_Zone_15"/>
+                <xs:enumeration value="Japan_Zone_16"/>
+                <xs:enumeration value="Japan_Zone_17"/>
+                <xs:enumeration value="Japan_Zone_18"/>
+                <xs:enumeration value="Japan_Zone_19"/>
+                <xs:enumeration value="Japan_Zone_2"/>
+                <xs:enumeration value="Japan_Zone_3"/>
+                <xs:enumeration value="Japan_Zone_4"/>
+                <xs:enumeration value="Japan_Zone_5"/>
+                <xs:enumeration value="Japan_Zone_6"/>
+                <xs:enumeration value="Japan_Zone_7"/>
+                <xs:enumeration value="Japan_Zone_8"/>
+                <xs:enumeration value="Japan_Zone_9"/>
+                <xs:enumeration value="Kertau_Singapore_Grid"/>
+                <xs:enumeration value="KOC_Lambert"/>
+                <xs:enumeration value="Korean_1985_Korea_Central_Belt"/>
+                <xs:enumeration value="Korean_1985_Korea_East_Belt"/>
+                <xs:enumeration value="Korean_1985_Korea_West_Belt"/>
+                <xs:enumeration value="KUDAMS_KTM"/>
+                <xs:enumeration value="KOC_Lambert"/>
+                <xs:enumeration value="KUDAMS_KTM"/>
+                <xs:enumeration value="Lake_Maracaibo_Grid_M1"/>
+                <xs:enumeration value="Lake_Maracaibo_Grid_M3"/>
+                <xs:enumeration value="Lake_Maracaibo_Grid"/>
+                <xs:enumeration value="Lake_Maracaibo_La_Rosa_Grid"/>
+                <xs:enumeration value="Lietuvos_Koordinaciu_Sistema"/>
+                <xs:enumeration value="Lisboa_Bessel_Bonne"/>
+                <xs:enumeration value="Lisboa_Hayford_Gauss_IGeoE"/>
+                <xs:enumeration value="Lisboa_Hayford_Gauss_IPCC"/>
+                <xs:enumeration value="Locodjo_1965_TM_5_NW"/>
+                <xs:enumeration value="Madrid_1870_Madrid_Spain"/>
+                <xs:enumeration value="MGI_3_Degree_Gauss_Zone_5"/>
+                <xs:enumeration value="MGI_3_Degree_Gauss_Zone_6"/>
+                <xs:enumeration value="MGI_3_Degree_Gauss_Zone_7"/>
+                <xs:enumeration value="MGI_3_Degree_Gauss_Zone_8"/>
+                <xs:enumeration value="MGI_Austria_Lambert"/>
+                <xs:enumeration value="MGI_Balkans_5"/>
+                <xs:enumeration value="MGI_Balkans_6"/>
+                <xs:enumeration value="MGI_Balkans_8"/>
+                <xs:enumeration value="MGI_Balkans_8"/>
+                <xs:enumeration value="MGI_M28"/>
+                <xs:enumeration value="MGI_M31"/>
+                <xs:enumeration value="MGI_M34"/>
+                <xs:enumeration value="Monte_Mario_Rome_Italy_1"/>
+                <xs:enumeration value="Monte_Mario_Rome_Italy_2"/>
+                <xs:enumeration value="Monte_Mario_Italy_1"/>
+                <xs:enumeration value="Monte_Mario_Italy_2"/>
+                <xs:enumeration value="Montserrat_1958_British_West_Indies_Grid"/>
+                <xs:enumeration value="Mount_Dillon_Tobago_Grid"/>
+                <xs:enumeration value="NAD_1927_Cuba_Norte"/>
+                <xs:enumeration value="NAD_1927_Cuba_Sur"/>
+                <xs:enumeration value="NAD_1927_Guatemala_Norte"/>
+                <xs:enumeration value="NAD_1927_Guatemala_Sur"/>
+                <xs:enumeration value="NAD_1927_Michigan_GeoRef_Meters"/>
+                <xs:enumeration value="NAD_1927_Michigan_GeoRef_Feet_US"/>
+                <xs:enumeration value="NAD_1983_HARN_Guam_Map_Grid"/>
+                <xs:enumeration value="NAD_1983_Michigan_GeoRef_Meters"/>
+                <xs:enumeration value="NAD_1983_Michigan_GeoRef_Feet_US"/>
+                <xs:enumeration value="GD_1949_New_Zealand_Map_Grid"/>
+                <xs:enumeration value="New_Zealand_North_Island"/>
+                <xs:enumeration value="New_Zealand_South_Island"/>
+                <xs:enumeration value="NZGD_1949_Amuri_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Bay_of_Plenty_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Bluff_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Buller_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Collingwood_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Gawler_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Grey_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Hawkes_Bay_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Hokitika_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Jacksons_Bay_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Karamea_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Lindis_Peak_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Marlborough_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Mount_Eden_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Mount_Nicholas_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Mount_Pleasant_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Mount_York_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Nelson_Circuit"/>
+                <xs:enumeration value="NZGD_1949_North_Taieri_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Observation_Point_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Okarito_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Poverty_Bay_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Taranaki_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Timaru_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Tuhirangi_Circuit"/>
+                <xs:enumeration value="NZGD_1949_UTM_Zone_58S"/>
+                <xs:enumeration value="NZGD_1949_UTM_Zone_59S"/>
+                <xs:enumeration value="NZGD_1949_UTM_Zone_60S"/>
+                <xs:enumeration value="NZGD_1949_Wairarapa_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Wanganui_Circuit"/>
+                <xs:enumeration value="NZGD_1949_Wellington_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Amuri_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Bay_of_Plenty_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Bluff_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Buller_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Collingwood_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Gawler_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Grey_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Hawkes_Bay_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Hokitika_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Jacksons_Bay_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Karamea_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Lindis_Peak_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Marlborough_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Mount_Eden_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Mount_Nicholas_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Mount_Pleasant_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Mount_York_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Nelson_Circuit"/>
+                <xs:enumeration value="NZGD_2000_North_Taieri_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Observation_Point_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Okarito_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Poverty_Bay_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Taranaki_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Timaru_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Tuhirangi_Circuit"/>
+                <xs:enumeration value="NZGD_2000_UTM_Zone_58S"/>
+                <xs:enumeration value="NZGD_2000_UTM_Zone_59S"/>
+                <xs:enumeration value="NZGD_2000_UTM_Zone_60S"/>
+                <xs:enumeration value="NZGD_2000_Wairarapa_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Wanganui_Circuit"/>
+                <xs:enumeration value="NZGD_2000_Wellington_Circuit"/>
+                <xs:enumeration value="GD_1949_New_Zealand_Map_Grid"/>
+                <xs:enumeration value="New_Zealand_North_Island"/>
+                <xs:enumeration value="New_Zealand_South_Island"/>
+                <xs:enumeration value="Nigeria_East_Belt"/>
+                <xs:enumeration value="Nigeria_Mid_Belt"/>
+                <xs:enumeration value="Nigeria_West_Belt"/>
+                <xs:enumeration value="Nord_Algerie_Degree"/>
+                <xs:enumeration value="Nord_Algerie_Ancienne_Degree"/>
+                <xs:enumeration value="Sud_Algerie_Ancienne"/>
+                <xs:enumeration value="Nord_Algerie"/>
+                <xs:enumeration value="Nord_de_Guerre"/>
+                <xs:enumeration value="Nord_France"/>
+                <xs:enumeration value="Nord_Maroc_Degree"/>
+                <xs:enumeration value="Nord_Maroc"/>
+                <xs:enumeration value="Nord_Tunisie"/>
+                <xs:enumeration value="NGO_1948_Baerum_Kommune"/>
+                <xs:enumeration value="NGO_1948_Bergenhalvoen"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_1"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_2"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_3"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_4"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_5"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_6"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_7"/>
+                <xs:enumeration value="NGO_1948_Norway_Zone_8"/>
+                <xs:enumeration value="NGO_1948_Oslo_Kommune"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_1"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_2"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_3"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_4"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_5"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_6"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_7"/>
+                <xs:enumeration value="NGO_1948_Oslo_Norway_Zone_8"/>
+                <xs:enumeration value="NTF_France_I_degrees"/>
+                <xs:enumeration value="NTF_France_II_degrees"/>
+                <xs:enumeration value="NTF_France_III_degrees"/>
+                <xs:enumeration value="NTF_France_IV_degrees"/>
+                <xs:enumeration value="Palestine_1923_Israel_CS_Grid"/>
+                <xs:enumeration value="Palestine_1923_Palestine_Belt"/>
+                <xs:enumeration value="Palestine_1923_Palestine_Grid"/>
+                <xs:enumeration value="Pampa_del_Castillo_Argentina_2"/>
+                <xs:enumeration value="Peru_Central_Zone"/>
+                <xs:enumeration value="Peru_East_Zone"/>
+                <xs:enumeration value="Peru_West_Zone"/>
+                <xs:enumeration value="Philippines_Zone_I"/>
+                <xs:enumeration value="Philippines_Zone_II"/>
+                <xs:enumeration value="Philippines_Zone_III"/>
+                <xs:enumeration value="Philippines_Zone_IV"/>
+                <xs:enumeration value="Philippines_Zone_V"/>
+                <xs:enumeration value="Portuguese_National_Grid"/>
+                <xs:enumeration value="Qatar_1948_Qatar_Grid"/>
+                <xs:enumeration value="Qatar_National_Grid"/>
+                <xs:enumeration value="RD_Old"/>
+                <xs:enumeration value="RGF_1993_Lambert_93"/>
+                <xs:enumeration value="Rijksdriehoekstelsel_New"/>
+                <xs:enumeration value="RT90_25_gon_W"/>
+                <xs:enumeration value="S-JTSK_Ferro_Krovak_East_North"/>
+                <xs:enumeration value="S-JTSK_Ferro_Krovak"/>
+                <xs:enumeration value="S-JTSK_Krovak_East_North"/>
+                <xs:enumeration value="S-JTSK_Krovak"/>
+                <xs:enumeration value="SAD_1969_Brazil_Polyconic"/>
+                <xs:enumeration value="Sahara_Degree"/>
+                <xs:enumeration value="Sahara"/>
+                <xs:enumeration value="Sierra_Leone_1924_New_Colony_Grid"/>
+                <xs:enumeration value="Sierra_Leone_1924_New_War_Office_Grid"/>
+                <xs:enumeration value="St_Kitts_1955_British_West_Indies_Grid"/>
+                <xs:enumeration value="St_Lucia_1955_British_West_Indies_Grid"/>
+                <xs:enumeration value="St_Vincent_1945_British_West_Indies_Grid"/>
+                <xs:enumeration value="Stereo_33"/>
+                <xs:enumeration value="Stereo_70"/>
+                <xs:enumeration value="Sud_Algerie_Degree"/>
+                <xs:enumeration value="Sud_Algerie_Ancienne_Degree"/>
+                <xs:enumeration value="Sud_Algerie"/>
+                <xs:enumeration value="Sud_France"/>
+                <xs:enumeration value="Sud_Maroc_Degree"/>
+                <xs:enumeration value="Sud_Maroc"/>
+                <xs:enumeration value="Sud_Tunisie"/>
+                <xs:enumeration value="Swedish_National_Grid"/>
+                <xs:enumeration value="Trinidad_1903_Trinidad_Grid"/>
+                <xs:enumeration value="UWPP_1992"/>
+                <xs:enumeration value="UWPP_2000_pas_5"/>
+                <xs:enumeration value="UWPP_2000_pas_6"/>
+                <xs:enumeration value="UWPP_2000_pas_7"/>
+                <xs:enumeration value="UWPP_2000_pas_8"/>
+                <xs:enumeration value="WGS_1972_BE_TM_106_NE"/>
+                <xs:enumeration value="WGS_1984_TM_36_SE"/>
+                <xs:enumeration value="Zanderij_Suriname_Old_TM"/>
+                <xs:enumeration value="Zanderij_Suriname_TM"/>
+                <xs:enumeration value="Zanderij_TM_54_NW"/>
+                <xs:enumeration value="North_Pole_Azimuthal_Equidistant"/>
+                <xs:enumeration value="North_Pole_Gnomonic"/>
+                <xs:enumeration value="North_Pole_Lambert_Azimuthal_Equal_Area"/>
+                <xs:enumeration value="North_Pole_Orthographic"/>
+                <xs:enumeration value="North_Pole_Stereographic"/>
+                <xs:enumeration value="South_Pole_Azimuthal_Equidistant"/>
+                <xs:enumeration value="South_Pole_Gnomonic"/>
+                <xs:enumeration value="South_Pole_Lambert_Azimuthal_Equal_Area"/>
+                <xs:enumeration value="South_Pole_Orthographic"/>
+                <xs:enumeration value="South_Pole_Stereographic"/>
+                <xs:enumeration value="UPS_North"/>
+                <xs:enumeration value="UPS_South"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alabama_East_FIPS_0101"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alabama_West_FIPS_0102"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_1_FIPS_5001"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_10_FIPS_5010"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_2_FIPS_5002"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_3_FIPS_5003"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_4_FIPS_5004"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_5_FIPS_5005"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_6_FIPS_5006"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_7_FIPS_5007"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_8_FIPS_5008"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Alaska_9_FIPS_5009"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Arizona_Central_FIPS_0202"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Arizona_East_FIPS_0201"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Arizona_West_FIPS_0203"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Arkansas_North_FIPS_0301"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Arkansas_South_FIPS_0302"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_I_FIPS_0401"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_II_FIPS_0402"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_III_FIPS_0403"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_IV_FIPS_0404"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_V_FIPS_0405"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_VI_FIPS_0406"/>
+                <xs:enumeration value="NAD_1927_StatePlane_California_VII_FIPS_0407"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Colorado_Central_FIPS_0502"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Colorado_North_FIPS_0501"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Colorado_South_FIPS_0503"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Connecticut_FIPS_0600"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Delaware_FIPS_0700"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Florida_East_FIPS_0901"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Florida_North_FIPS_0903"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Florida_West_FIPS_0902"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Georgia_East_FIPS_1001"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Georgia_West_FIPS_1002"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Guam_FIPS_5400"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Idaho_Central_FIPS_1102"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Idaho_East_FIPS_1101"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Idaho_West_FIPS_1103"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Illinois_East_FIPS_1201"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Illinois_West_FIPS_1202"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Indiana_East_FIPS_1301"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Indiana_West_FIPS_1302"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Iowa_North_FIPS_1401"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Iowa_South_FIPS_1402"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Kansas_North_FIPS_1501"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Kansas_South_FIPS_1502"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Kentucky_North_FIPS_1601"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Kentucky_South_FIPS_1602"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Louisiana_North_FIPS_1701"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Louisiana_South_FIPS_1702"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Maine_East_FIPS_1801"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Maine_West_FIPS_1802"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Maryland_FIPS_1900"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Massachusetts_Island_FIPS_2002"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Massachusetts_Mainland_FIPS_2001"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Michigan_Central_FIPS_2112"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Michigan_North_FIPS_2111"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Michigan_South_FIPS_2113"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Minnesota_Central_FIPS_2202"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Minnesota_North_FIPS_2201"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Minnesota_South_FIPS_2203"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Mississippi_East_FIPS_2301"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Mississippi_West_FIPS_2302"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Missouri_Central_FIPS_2402"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Missouri_East_FIPS_2401"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Missouri_West_FIPS_2403"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Montana_Central_FIPS_2502"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Montana_North_FIPS_2501"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Montana_South_FIPS_2503"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Nebraska_North_FIPS_2601"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Nebraska_South_FIPS_2602"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Nevada_Central_FIPS_2702"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Nevada_East_FIPS_2701"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Nevada_West_FIPS_2703"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_Hampshire_FIPS_2800"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_Jersey_FIPS_2900"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_Mexico_Central_FIPS_3002"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_Mexico_East_FIPS_3001"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_Mexico_West_FIPS_3003"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_York_Central_FIPS_3102"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_York_East_FIPS_3101"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_York_Long_Island_FIPS_3104"/>
+                <xs:enumeration value="NAD_1927_StatePlane_New_York_West_FIPS_3103"/>
+                <xs:enumeration value="NAD_1927_StatePlane_North_Carolina_FIPS_3200"/>
+                <xs:enumeration value="NAD_1927_StatePlane_North_Dakota_North_FIPS_3301"/>
+                <xs:enumeration value="NAD_1927_StatePlane_North_Dakota_South_FIPS_3302"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Ohio_North_FIPS_3401"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Ohio_South_FIPS_3402"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Oklahoma_North_FIPS_3501"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Oklahoma_South_FIPS_3502"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Oregon_North_FIPS_3601"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Oregon_South_FIPS_3602"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Pennsylvania_North_FIPS_3701"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Pennsylvania_South_FIPS_3702"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Puerto_Rico_FIPS_5201"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Rhode_Island_FIPS_3800"/>
+                <xs:enumeration value="NAD_1927_StatePlane_South_Carolina_North_FIPS_3901"/>
+                <xs:enumeration value="NAD_1927_StatePlane_South_Carolina_South_FIPS_3902"/>
+                <xs:enumeration value="NAD_1927_StatePlane_South_Dakota_North_FIPS_4001"/>
+                <xs:enumeration value="NAD_1927_StatePlane_South_Dakota_South_FIPS_4002"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Tennessee_FIPS_4100"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Texas_Central_FIPS_4203"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Texas_North_Central_FIPS_4202"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Texas_North_FIPS_4201"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Texas_South_Central_FIPS_4204"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Texas_South_FIPS_4205"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Utah_Central_FIPS_4302"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Utah_North_FIPS_4301"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Utah_South_FIPS_4303"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Vermont_FIPS_3400"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Virginia_North_FIPS_4501"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Virginia_South_FIPS_4502"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Washington_North_FIPS_4601"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Washington_South_FIPS_4602"/>
+                <xs:enumeration value="NAD_1927_StatePlane_West_Virginia_North_FIPS_4701"/>
+                <xs:enumeration value="NAD_1927_StatePlane_West_Virginia_South_FIPS_4702"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wisconsin_Central_FIPS_4802"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wisconsin_North_FIPS_4801"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wisconsin_South_FIPS_4803"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wyoming_East_Central_FIPS_4902"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wyoming_East_FIPS_4901"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wyoming_West_Central_FIPS_4903"/>
+                <xs:enumeration value="NAD_1927_StatePlane_Wyoming_West_FIPS_4904"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alabama_East_FIPS_0101"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alabama_West_FIPS_0102"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_1_FIPS_5001"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_10_FIPS_5010"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_2_FIPS_5002"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_3_FIPS_5003"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_4_FIPS_5004"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_5_FIPS_5005"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_6_FIPS_5006"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_7_FIPS_5007"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_8_FIPS_5008"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_9_FIPS_5009"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arizona_Central_FIPS_0202"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arizona_East_FIPS_0201"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arizona_West_FIPS_0203"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arkansas_North_FIPS_0301"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arkansas_South_FIPS_0302"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_I_FIPS_0401"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_II_FIPS_0402"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_III_FIPS_0403"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_IV_FIPS_0404"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_V_FIPS_0405"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_VI_FIPS_0406"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Colorado_Central_FIPS_0502"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Colorado_North_FIPS_0501"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Colorado_South_FIPS_0503"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Connecticut_FIPS_0600"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Delaware_FIPS_0700"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Florida_East_FIPS_0901"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Florida_North_FIPS_0903"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Florida_West_FIPS_0902"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Georgia_East_FIPS_1001"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Georgia_West_FIPS_1002"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Guam_FIPS_5400"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_1_FIPS_5101"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_2_FIPS_5102"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_3_FIPS_5103"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_4_FIPS_5104"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_5_FIPS_5105"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Idaho_Central_FIPS_1102"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Idaho_East_FIPS_1101"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Idaho_West_FIPS_1103"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Illinois_East_FIPS_1201"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Illinois_West_FIPS_1202"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Indiana_East_FIPS_1301"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Indiana_West_FIPS_1302"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Iowa_North_FIPS_1401"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Iowa_South_FIPS_1402"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kansas_North_FIPS_1501"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kansas_South_FIPS_1502"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kentucky_FIPS_1600"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kentucky_North_FIPS_1601"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kentucky_South_FIPS_1602"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Louisiana_North_FIPS_1701"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Louisiana_South_FIPS_1702"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Maine_East_FIPS_1801"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Maine_West_FIPS_1802"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Maryland_FIPS_1900"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Massachusetts_Island_FIPS_2002"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Massachusetts_Mainland_FIPS_2001"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Michigan_Central_FIPS_2202"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Michigan_North_FIPS_2111"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Michigan_South_FIPS_2113"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Minnesota_Central_FIPS_2202"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Minnesota_North_FIPS_2201"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Minnesota_South_FIPS_2203"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Mississippi_East_FIPS_2301"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Mississippi_West_FIPS_2302"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Missouri_Central_FIPS_2402"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Missouri_East_FIPS_2401"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Missouri_West_FIPS_2403"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Montana_FIPS_2500"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nebraska_FIPS_2600"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nevada_Central_FIPS_2702"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nevada_East_FIPS_2701"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nevada_West_FIPS_2703"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Hampshire_FIPS_2800"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Jersey_FIPS_2900"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Mexico_Central_FIPS_3002"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Mexico_East_FIPS_3001"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Mexico_West_FIPS_3003"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_Central_FIPS_3102"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_East_FIPS_3101"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_Long_Island_FIPS_3104"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_West_FIPS_3103"/>
+                <xs:enumeration value="NAD_1983_StatePlane_North_Carolina_FIPS_3200"/>
+                <xs:enumeration value="NAD_1983_StatePlane_North_Dakota_North_FIPS_3301"/>
+                <xs:enumeration value="NAD_1983_StatePlane_North_Dakota_South_FIPS_3302"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Ohio_North_FIPS_3401"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Ohio_South_FIPS_3402"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oklahoma_North_FIPS_3501"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oklahoma_South_FIPS_3502"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oregon_North_FIPS_3601"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oregon_South_FIPS_3602"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Pennsylvania_North_FIPS_3701"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Pennsylvania_South_FIPS_3702"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Puerto_Rico_Virgin_Islands_FIPS_5200"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Rhode_Island_FIPS_3800"/>
+                <xs:enumeration value="NAD_1983_StatePlane_South_Carolina_FIPS_3900"/>
+                <xs:enumeration value="NAD_1983_StatePlane_South_Dakota_North_FIPS_4001"/>
+                <xs:enumeration value="NAD_1983_StatePlane_South_Dakota_South_FIPS_4002"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Tennessee_FIPS_4100"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_Central_FIPS_4203"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_North_Central_FIPS_4202"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_North_FIPS_4201"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_South_Central_FIPS_4204"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_South_FIPS_4205"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Utah_Central_FIPS_4302"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Utah_North_FIPS_4301"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Utah_South_FIPS_4303"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Vermont_FIPS_4400"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Virginia_North_FIPS_4501"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Virginia_South_FIPS_4502"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Washington_North_FIPS_4601"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Washington_South_FIPS_4602"/>
+                <xs:enumeration value="NAD_1983_StatePlane_West_Virginia_North_FIPS_4701"/>
+                <xs:enumeration value="NAD_1983_StatePlane_West_Virginia_South_FIPS_4702"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wisconsin_Central_FIPS_4802"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wisconsin_North_FIPS_4801"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wisconsin_South_FIPS_4803"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_East_Central_FIPS_4902"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_East_FIPS_4901"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_West_Central_FIPS_4903"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_West_FIPS_4904"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alabama_East_FIPS_0101_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alabama_West_FIPS_0102_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_1_FIPS_5001_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_10_FIPS_5010_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_2_FIPS_5002_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_3_FIPS_5003_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_4_FIPS_5004_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_5_FIPS_5005_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_6_FIPS_5006_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_7_FIPS_5007_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_8_FIPS_5008_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Alaska_9_FIPS_5009_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arizona_Central_FIPS_0202_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arizona_East_FIPS_0201_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arizona_West_FIPS_0203_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arkansas_North_FIPS_0301_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Arkansas_South_FIPS_0302_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_I_FIPS_0401_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_II_FIPS_0402_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_III_FIPS_0403_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_IV_FIPS_0404_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_V_FIPS_0405_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_California_VI_FIPS_0406_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Colorado_Central_FIPS_0502_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Colorado_North_FIPS_0501_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Colorado_South_FIPS_0503_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Connecticut_FIPS_0600_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Delaware_FIPS_0700_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Florida_East_FIPS_0901_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Florida_North_FIPS_0903_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Florida_West_FIPS_0902_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Georgia_East_FIPS_1001_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Georgia_West_FIPS_1002_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Guam_FIPS_5400_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_1_FIPS_5101_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_2_FIPS_5102_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_3_FIPS_5103_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_4_FIPS_5104_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Hawaii_5_FIPS_5105_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Idaho_Central_FIPS_1102_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Idaho_East_FIPS_1101_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Idaho_West_FIPS_1103_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Illinois_East_FIPS_1201_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Illinois_West_FIPS_1202_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Indiana_East_FIPS_1301_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Indiana_West_FIPS_1302_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Iowa_North_FIPS_1401_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Iowa_South_FIPS_1402_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kansas_North_FIPS_1501_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kansas_South_FIPS_1502_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kentucky_FIPS_1600_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kentucky_North_FIPS_1601_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Kentucky_South_FIPS_1602_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Louisiana_North_FIPS_1701_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Louisiana_South_FIPS_1702_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Maine_East_FIPS_1801_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Maine_West_FIPS_1802_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Maryland_FIPS_1900_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Massachusetts_Island_FIPS_2002_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Massachusetts_Mainland_FIPS_2001_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Michigan_Central_FIPS_2202_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Michigan_North_FIPS_2111_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Michigan_South_FIPS_2113_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Minnesota_Central_FIPS_2202_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Minnesota_North_FIPS_2201_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Minnesota_South_FIPS_2203_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Mississippi_East_FIPS_2301_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Mississippi_West_FIPS_2302_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Missouri_Central_FIPS_2402_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Missouri_East_FIPS_2401_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Missouri_West_FIPS_2403_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Montana_FIPS_2500_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nebraska_FIPS_2600_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nevada_Central_FIPS_2702_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nevada_East_FIPS_2701_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Nevada_West_FIPS_2703_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Hampshire_FIPS_2800_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Jersey_FIPS_2900_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Mexico_Central_FIPS_3002_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Mexico_East_FIPS_3001_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_Mexico_West_FIPS_3003_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_Central_FIPS_3102_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_East_FIPS_3101_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_Long_Island_FIPS_3104_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_New_York_West_FIPS_3103_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_North_Carolina_FIPS_3200_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_North_Dakota_North_FIPS_3301_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_North_Dakota_South_FIPS_3302_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Ohio_North_FIPS_3401_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Ohio_South_FIPS_3402_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oklahoma_North_FIPS_3501_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oklahoma_South_FIPS_3502_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oregon_North_FIPS_3601_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Oregon_South_FIPS_3602_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Pennsylvania_North_FIPS_3701_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Pennsylvania_South_FIPS_3702_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Puerto_Rico_Virgin_Islands_FIPS_5200_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Rhode_Island_FIPS_3800_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_South_Carolina_FIPS_3900_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_South_Dakota_North_FIPS_4001_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_South_Dakota_South_FIPS_4002_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Tennessee_FIPS_4100_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_Central_FIPS_4203_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_North_Central_FIPS_4202_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_North_FIPS_4201_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_South_Central_FIPS_4204_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Texas_South_FIPS_4205_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Utah_Central_FIPS_4302_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Utah_North_FIPS_4301_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Utah_South_FIPS_4303_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Vermont_FIPS_4400_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Virginia_North_FIPS_4501_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Virginia_South_FIPS_4502_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Washington_North_FIPS_4601_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Washington_South_FIPS_4602_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_West_Virginia_North_FIPS_4701_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_West_Virginia_South_FIPS_4702_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wisconsin_Central_FIPS_4802_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wisconsin_North_FIPS_4801_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wisconsin_South_FIPS_4803_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_East_Central_FIPS_4902_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_East_FIPS_4901_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_West_Central_FIPS_4903_Feet"/>
+                <xs:enumeration value="NAD_1983_StatePlane_Wyoming_West_FIPS_4904_Feet"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Alabama_East_FIPS_0101"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Alabama_West_FIPS_0102"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Arizona_Central_FIPS_0202"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Arizona_East_FIPS_0201"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Arizona_West_FIPS_0203"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_California_I_FIPS_0401"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_California_II_FIPS_0402"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_California_III_FIPS_0403"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_California_IV_FIPS_0404"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_California_V_FIPS_0405"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_California_VI_FIPS_0406"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Colorado_Central_FIPS_0502"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Colorado_North_FIPS_0501"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Colorado_South_FIPS_0503"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Connecticut_FIPS_0600"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Delaware_FIPS_0700"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Florida_East_FIPS_0901"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Florida_North_FIPS_0903"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Florida_West_FIPS_0902"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Georgia_East_FIPS_1001"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Georgia_West_FIPS_1002"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Hawaii_1_FIPS_5101"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Hawaii_2_FIPS_5102"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Hawaii_3_FIPS_5103"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Hawaii_4_FIPS_5104"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Hawaii_5_FIPS_5105"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Idaho_Central_FIPS_1102"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Idaho_East_FIPS_1101"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Idaho_West_FIPS_1103"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Illinois_East_FIPS_1201"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Illinois_West_FIPS_1202"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Indiana_East_FIPS_1301"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Indiana_West_FIPS_1302"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Kansas_North_FIPS_1501"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Kansas_South_FIPS_1502"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Kentucky_North_FIPS_1601"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Kentucky_South_FIPS_1602"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Louisiana_North_FIPS_1701"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Louisiana_South_FIPS_1702"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Maine_East_FIPS_1801"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Maine_West_FIPS_1802"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Maryland_FIPS_1900"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Massachusetts_Island_FIPS_2002"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Massachusetts_Mainland_FIPS_2001"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Michigan_Central_FIPS_2202"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Michigan_North_FIPS_2111"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Michigan_South_FIPS_2113"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Mississippi_East_FIPS_2301"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Mississippi_West_FIPS_2302"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Montana_FIPS_2500"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Nebraska_FIPS_2600"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Nevada_Central_FIPS_2702"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Nevada_East_FIPS_2701"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Nevada_West_FIPS_2703"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_Hampshire_FIPS_2800"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_Jersey_FIPS_2900"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_Mexico_Central_FIPS_3002"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_Mexico_East_FIPS_3001"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_Mexico_West_FIPS_3003"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_York_Central_FIPS_3102"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_York_East_FIPS_3101"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_York_Long_Island_FIPS_3104"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_New_York_West_FIPS_3103"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_North_Dakota_North_FIPS_3301"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_North_Dakota_South_FIPS_3302"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Ohio_North_FIPS_3401"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Ohio_South_FIPS_3402"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Oklahoma_North_FIPS_3501"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Oklahoma_South_FIPS_3502"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Oregon_North_FIPS_3601"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Oregon_South_FIPS_3602"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Puerto_Rico_Virgin_Islands_FIPS_5200"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Rhode_Island_FIPS_3800"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_South_Dakota_North_FIPS_4001"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_South_Dakota_South_FIPS_4002"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Tennessee_FIPS_4100"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Texas_Central_FIPS_4203"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Texas_North_Central_FIPS_4202"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Texas_North_FIPS_4201"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Texas_South_Central_FIPS_4204"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Texas_South_FIPS_4205"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Utah_Central_FIPS_4302"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Utah_North_FIPS_4301"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Utah_South_FIPS_4303"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Vermont_FIPS_4400"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Virginia_North_FIPS_4501"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Virginia_South_FIPS_4502"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Washington_North_FIPS_4601"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Washington_South_FIPS_4602"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_West_Virginia_North_FIPS_4701"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_West_Virginia_South_FIPS_4702"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wisconsin_Central_FIPS_4802"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wisconsin_North_FIPS_4801"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wisconsin_South_FIPS_4803"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wyoming_East_FIPS_4901"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wyoming_East_Central_FIPS_4902"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wyoming_West_Central_FIPS_4903"/>
+                <xs:enumeration value="NAD_1983_HARN_StatePlane_Wyoming_West_FIPS_4904"/>
+                <xs:enumeration value="American_Samoa_1962_StatePlane_American_Samoa_FIPS_5300"/>
+                <xs:enumeration value="NAD_1983_HARN_Guam_Map_Grid"/>
+                <xs:enumeration value="NAD_1983_HARN_UTM_Zone_2S"/>
+                <xs:enumeration value="NAD_Michigan_StatePlane_Michigan_Central_FIPS_2112"/>
+                <xs:enumeration value="NAD_Michigan_StatePlane_Michigan_Central_Old_FIPS_2102"/>
+                <xs:enumeration value="NAD_Michigan_StatePlane_Michigan_East_Old_FIPS_2101"/>
+                <xs:enumeration value="NAD_Michigan_StatePlane_Michigan_North_FIPS_2111"/>
+                <xs:enumeration value="NAD_Michigan_StatePlane_Michigan_South_FIPS_2113"/>
+                <xs:enumeration value="NAD_Michigan_StatePlane_Michigan_West_Old_FIPS_2103"/>
+                <xs:enumeration value="Old_Hawaiian_StatePlane_Hawaii_1_FIPS_5101"/>
+                <xs:enumeration value="Old_Hawaiian_StatePlane_Hawaii_2_FIPS_5102"/>
+                <xs:enumeration value="Old_Hawaiian_StatePlane_Hawaii_3_FIPS_5103"/>
+                <xs:enumeration value="Old_Hawaiian_StatePlane_Hawaii_4_FIPS_5104"/>
+                <xs:enumeration value="Old_Hawaiian_StatePlane_Hawaii_5_FIPS_5105"/>
+                <xs:enumeration value="Puerto_Rico_StatePlane_Puerto_Rico_FIPS_5201"/>
+                <xs:enumeration value="Puerto_Rico_StatePlane_Virgin_Islands_St_Croix_FIPS_5202"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_10N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_11N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_12N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_13N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_14N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_15N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_16N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_17N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_18N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_19N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_20N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_21N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_22N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_3N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_4N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_5N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_6N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_7N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_8N"/>
+                <xs:enumeration value="NAD_1927_UTM_Zone_9N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_10N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_11N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_12N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_13N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_14N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_15N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_16N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_17N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_18N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_19N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_20N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_21N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_22N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_23N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_3N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_4N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_5N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_6N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_7N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_8N"/>
+                <xs:enumeration value="NAD_1983_UTM_Zone_9N"/>
+                <xs:enumeration value="Abidjan_1987_UTM_Zone_29N"/>
+                <xs:enumeration value="Abidjan_1987_UTM_Zone_30N"/>
+                <xs:enumeration value="Adindan_UTM_Zone_37N"/>
+                <xs:enumeration value="Adindan_UTM_Zone_38N"/>
+                <xs:enumeration value="Afgooye_UTM_Zone_38N"/>
+                <xs:enumeration value="Afgooye_UTM_Zone_39N"/>
+                <xs:enumeration value="Ain_el_Abd_UTM_Zone_37N"/>
+                <xs:enumeration value="Ain_el_Abd_UTM_Zone_38N"/>
+                <xs:enumeration value="Ain_el_Abd_UTM_Zone_39N"/>
+                <xs:enumeration value="Aratu_UTM_Zone_22S"/>
+                <xs:enumeration value="Aratu_UTM_Zone_23S"/>
+                <xs:enumeration value="Aratu_UTM_Zone_24S"/>
+                <xs:enumeration value="Arc_1950_UTM_Zone_34S"/>
+                <xs:enumeration value="Arc_1950_UTM_Zone_35S"/>
+                <xs:enumeration value="Arc_1950_UTM_Zone_36S"/>
+                <xs:enumeration value="Arc_1960_UTM_Zone_35N"/>
+                <xs:enumeration value="Arc_1960_UTM_Zone_35S"/>
+                <xs:enumeration value="Arc_1960_UTM_Zone_36N"/>
+                <xs:enumeration value="Arc_1960_UTM_Zone_36S"/>
+                <xs:enumeration value="Arc_1960_UTM_Zone_37N"/>
+                <xs:enumeration value="Arc_1960_UTM_Zone_37S"/>
+                <xs:enumeration value="ATS_1977_UTM_Zone_19N"/>
+                <xs:enumeration value="ATS_1977_UTM_Zone_20N"/>
+                <xs:enumeration value="Batavia_UTM_Zone_48S"/>
+                <xs:enumeration value="Batavia_UTM_Zone_49S"/>
+                <xs:enumeration value="Batavia_UTM_Zone_50S"/>
+                <xs:enumeration value="Bissau_UTM_Zone_28N"/>
+                <xs:enumeration value="Bogota_UTM_Zone_17N"/>
+                <xs:enumeration value="Bogota_UTM_Zone_18N"/>
+                <xs:enumeration value="Camacupa_UTM_Zone_32S"/>
+                <xs:enumeration value="Camacupa_UTM_Zone_33S"/>
+                <xs:enumeration value="Cape_UTM_Zone_34S"/>
+                <xs:enumeration value="Cape_UTM_Zone_35S"/>
+                <xs:enumeration value="Cape_UTM_Zone_36S"/>
+                <xs:enumeration value="Carthage_UTM_Zone_32N"/>
+                <xs:enumeration value="Conakry_1905_UTM_Zone_28N"/>
+                <xs:enumeration value="Conakry_1905_UTM_Zone_29N"/>
+                <xs:enumeration value="Corrego_Alegre_UTM_Zone_23S"/>
+                <xs:enumeration value="Corrego_Alegre_UTM_Zone_24S"/>
+                <xs:enumeration value="Dabola_UTM_Zone_28N"/>
+                <xs:enumeration value="Dabola_UTM_Zone_29N"/>
+                <xs:enumeration value="Datum_73_UTM_Zone_29N"/>
+                <xs:enumeration value="Douala_UTM_Zone_32N"/>
+                <xs:enumeration value="ED_1950_ED77_UTM_Zone_38N"/>
+                <xs:enumeration value="ED_1950_ED77_UTM_Zone_39N"/>
+                <xs:enumeration value="ED_1950_ED77_UTM_Zone_40N"/>
+                <xs:enumeration value="ED_1950_ED77_UTM_Zone_41N"/>
+                <xs:enumeration value="ELD_1979_UTM_Zone_32N"/>
+                <xs:enumeration value="ELD_1979_UTM_Zone_33N"/>
+                <xs:enumeration value="ELD_1979_UTM_Zone_34N"/>
+                <xs:enumeration value="ELD_1979_UTM_Zone_35N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_28N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_29N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_30N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_31N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_32N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_33N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_34N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_35N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_36N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_37N"/>
+                <xs:enumeration value="ETRF_1989_UTM_Zone_38N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_28N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_29N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_30N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_31N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_32N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_33N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_34N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_35N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_36N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_37N"/>
+                <xs:enumeration value="ED_1950_UTM_Zone_38N"/>
+                <xs:enumeration value="Fahud_UTM_Zone_39N"/>
+                <xs:enumeration value="Fahud_UTM_Zone_40N"/>
+                <xs:enumeration value="Garoua_UTM_Zone_33N"/>
+                <xs:enumeration value="Graciosa_Base_SW_1948_UTM_Zone_26N"/>
+                <xs:enumeration value="Hito_XVIII_1963_UTM_19S"/>
+                <xs:enumeration value="Hong_Kong_1980_UTM_Zone_49N"/>
+                <xs:enumeration value="Hong_Kong_1980_UTM_Zone_50N"/>
+                <xs:enumeration value="Indian_1954_UTM_Zone_46N"/>
+                <xs:enumeration value="Indian_1954_UTM_Zone_47N"/>
+                <xs:enumeration value="Indian_1954_UTM_Zone_48N"/>
+                <xs:enumeration value="Indian_1960_UTM_Zone_48N"/>
+                <xs:enumeration value="Indian_1960_UTM_Zone_49N"/>
+                <xs:enumeration value="Indian_1975_UTM_Zone_47N"/>
+                <xs:enumeration value="Indian_1975_UTM_Zone_48N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_46N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_46S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_47N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_47S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_48N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_48S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_49N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_49S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_50N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_50S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_51N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_51S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_52N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_52S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_53N"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_53S"/>
+                <xs:enumeration value="Indonesian_1974_UTM_Zone_54S"/>
+                <xs:enumeration value="IRENET95_UTM_Zone_29N"/>
+                <xs:enumeration value="Kertau_UTM_Zone_47N"/>
+                <xs:enumeration value="Kertau_UTM_Zone_48N"/>
+                <xs:enumeration value="La_Canoa_UTM_Zone_18N"/>
+                <xs:enumeration value="La_Canoa_UTM_Zone_19N"/>
+                <xs:enumeration value="La_Canoa_UTM_Zone_20N"/>
+                <xs:enumeration value="La_Canoa_UTM_Zone_21N"/>
+                <xs:enumeration value="Locodjo_1965_UTM_Zone_29N"/>
+                <xs:enumeration value="Locodjo_1965_UTM_Zone_30N"/>
+                <xs:enumeration value="Lome_UTM_Zone_31N"/>
+                <xs:enumeration value="Mporaloko_UTM_Zone_32N"/>
+                <xs:enumeration value="Mporaloko_UTM_Zone_32S"/>
+                <xs:enumeration value="Malongo_1987_UTM_Zone_32S"/>
+                <xs:enumeration value="Massawa_UTM_Zone_37N"/>
+                <xs:enumeration value="Mhast_UTM_Zone_32S"/>
+                <xs:enumeration value="Minna_UTM_Zone_31N"/>
+                <xs:enumeration value="Minna_UTM_Zone_32N"/>
+                <xs:enumeration value="Moznet_UTM_Zone_36S"/>
+                <xs:enumeration value="Moznet_UTM_Zone_37S"/>
+                <xs:enumeration value="NAD_1927_BLM_Zone_14N"/>
+                <xs:enumeration value="NAD_1927_BLM_Zone_15N"/>
+                <xs:enumeration value="NAD_1927_BLM_Zone_16N"/>
+                <xs:enumeration value="NAD_1927_BLM_Zone_17N"/>
+                <xs:enumeration value="NAD_1983_HARN_UTM_Zone_2S"/>
+                <xs:enumeration value="Nahrwan_1967_UTM_Zone_38N"/>
+                <xs:enumeration value="Nahrwan_1967_UTM_Zone_39N"/>
+                <xs:enumeration value="Nahrwan_1967_UTM_Zone_40N"/>
+                <xs:enumeration value="Naparima_1955_UTM_Zone_20N"/>
+                <xs:enumeration value="Naparima_1972_UTM_Zone_20N"/>
+                <xs:enumeration value="NGN_UTM_Zone_38N"/>
+                <xs:enumeration value="NGN_UTM_Zone_39N"/>
+                <xs:enumeration value="NGO_1948_UTM_Zone_32N"/>
+                <xs:enumeration value="NGO_1948_UTM_Zone_33N"/>
+                <xs:enumeration value="NGO_1948_UTM_Zone_34N"/>
+                <xs:enumeration value="NGO_1948_UTM_Zone_35N"/>
+                <xs:enumeration value="Nord_Sahara_1959_UTM_Zone_29N"/>
+                <xs:enumeration value="Nord_Sahara_1959_UTM_Zone_30N"/>
+                <xs:enumeration value="Nord_Sahara_1959_UTM_Zone_31N"/>
+                <xs:enumeration value="Nord_Sahara_1959_UTM_Zone_32N"/>
+                <xs:enumeration value="NZGD_1949_UTM_Zone_58S"/>
+                <xs:enumeration value="NZGD_1949_UTM_Zone_59S"/>
+                <xs:enumeration value="NZGD_1949_UTM_Zone_60S"/>
+                <xs:enumeration value="NZGD_2000_UTM_Zone_58S"/>
+                <xs:enumeration value="NZGD_2000_UTM_Zone_59S"/>
+                <xs:enumeration value="NZGD_2000_UTM_Zone_60S"/>
+                <xs:enumeration value="Observ_Meteorologico_1939_UTM_Zone_25N"/>
+                <xs:enumeration value="Old_Hawaiian_UTM_Zone_4N"/>
+                <xs:enumeration value="Old_Hawaiian_UTM_Zone_5N"/>
+                <xs:enumeration value="PDO_1993_UTM_Zone_39N"/>
+                <xs:enumeration value="PDO_1993_UTM_Zone_40N"/>
+                <xs:enumeration value="Pointe_Noire_UTM_Zone_32S"/>
+                <xs:enumeration value="Porto_Santo_1936_UTM_Zone_28N"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_17S"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_18N"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_18S"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_19N"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_19S"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_20N"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_20S"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_21N"/>
+                <xs:enumeration value="PSAD_1956_UTM_Zone_22S"/>
+                <xs:enumeration value="Puerto_Rico_UTM_Zone_20N"/>
+                <xs:enumeration value="Samboja_UTM_Zone_50S"/>
+                <xs:enumeration value="Sao_Braz_UTM_Zone_26N"/>
+                <xs:enumeration value="Sapper_Hill_1943_UTM_Zone_20S"/>
+                <xs:enumeration value="Sapper_Hill_1943_UTM_Zone_21S"/>
+                <xs:enumeration value="Schwarzeck_UTM_Zone_33S"/>
+                <xs:enumeration value="Selvagem_Grande_1938_UTM_Zone_28N"/>
+                <xs:enumeration value="Sierra_Leone_1968_UTM_Zone_28N"/>
+                <xs:enumeration value="Sierra_Leone_1968_UTM_Zone_29N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_17N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_17S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_18N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_18S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_19N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_19S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_20N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_20S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_21N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_21S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_22N"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_22S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_23S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_24S"/>
+                <xs:enumeration value="SIRGAS_UTM_Zone_25S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_17S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_18N"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_18S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_19N"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_19S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_20N"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_20S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_21N"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_21S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_22N"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_22S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_23S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_24S"/>
+                <xs:enumeration value="SAD_1969_UTM_Zone_25S"/>
+                <xs:enumeration value="Sudan_UTM_Zone_35N"/>
+                <xs:enumeration value="Sudan_UTM_Zone_36N"/>
+                <xs:enumeration value="Tananarive_1925_UTM_Zone_38S"/>
+                <xs:enumeration value="Tananarive_1925_UTM_Zone_39S"/>
+                <xs:enumeration value="Tete_UTM_Zone_36S"/>
+                <xs:enumeration value="Tete_UTM_Zone_37S"/>
+                <xs:enumeration value="Timbalai_1948_UTM_Zone_49N"/>
+                <xs:enumeration value="Timbalai_1948_UTM_Zone_50N"/>
+                <xs:enumeration value="Tokyo_UTM_Zone_51N"/>
+                <xs:enumeration value="Tokyo_UTM_Zone_52N"/>
+                <xs:enumeration value="Tokyo_UTM_Zone_53N"/>
+                <xs:enumeration value="Tokyo_UTM_Zone_54N"/>
+                <xs:enumeration value="Tokyo_UTM_Zone_55N"/>
+                <xs:enumeration value="Tokyo_UTM_Zone_56N"/>
+                <xs:enumeration value="TC_1948_UTM_Zone_39N"/>
+                <xs:enumeration value="TC_1948_UTM_Zone_40N"/>
+                <xs:enumeration value="Yemen_NGN_1996_UTM_Zone_38N"/>
+                <xs:enumeration value="Yemen_NGN_1996_UTM_Zone_39N"/>
+                <xs:enumeration value="Yoff_1972_UTM_Zone_28N"/>
+                <xs:enumeration value="Zanderij_1972_UTM_Zone_21N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_10N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_10S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_11N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_11S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_12N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_12S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_13N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_13S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_14N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_14S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_15N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_15S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_16N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_16S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_17N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_17S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_18N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_18S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_19N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_19S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_1N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_1S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_20N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_20S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_21N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_21S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_22N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_22S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_23N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_23S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_24N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_24S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_25N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_25S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_26N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_26S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_27N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_27S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_28N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_28S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_29N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_29S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_2N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_2S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_30N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_30S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_31N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_31S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_32N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_32S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_33N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_33S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_34N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_34S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_35N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_35S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_36N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_36S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_37N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_37S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_38N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_38S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_39N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_39S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_3N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_3S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_40N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_40S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_41N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_41S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_42N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_42S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_43N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_43S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_44N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_44S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_45N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_45S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_46N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_46S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_47N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_47S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_48N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_48S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_49N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_49S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_4N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_4S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_50N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_50S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_51N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_51S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_52N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_52S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_53N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_53S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_54N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_54S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_55N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_55S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_56N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_56S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_57N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_57S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_58N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_58S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_59N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_59S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_5N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_5S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_60N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_60S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_6N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_6S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_7N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_7S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_8N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_8S"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_9N"/>
+                <xs:enumeration value="WGS_1972_UTM_Zone_9S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_10N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_10S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_11N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_11S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_12N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_12S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_13N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_13S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_14N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_14S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_15N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_15S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_16N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_16S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_17N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_17S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_18N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_18S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_19N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_19S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_1N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_1S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_20N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_20S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_21N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_21S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_22N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_22S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_23N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_23S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_24N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_24S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_25N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_25S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_26N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_26S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_27N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_27S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_28N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_28S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_29N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_29S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_2N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_2S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_30N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_30S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_31N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_31S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_32N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_32S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_33N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_33S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_34N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_34S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_35N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_35S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_36N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_36S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_37N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_37S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_38N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_38S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_39N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_39S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_3N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_3S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_40N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_40S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_41N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_41S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_42N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_42S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_43N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_43S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_44N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_44S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_45N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_45S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_46N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_46S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_47N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_47S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_48N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_48S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_49N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_49S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_4N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_4S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_50N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_50S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_51N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_51S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_52N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_52S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_53N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_53S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_54N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_54S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_55N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_55S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_56N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_56S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_57N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_57S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_58N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_58S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_59N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_59S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_5N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_5S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_60N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_60S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_6N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_6S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_7N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_7S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_8N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_8S"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_9N"/>
+                <xs:enumeration value="WGS_1984_UTM_Zone_9S"/>
+                <xs:enumeration value="World_Aitoff"/>
+                <xs:enumeration value="World_Behrmann"/>
+                <xs:enumeration value="World_Bonne"/>
+                <xs:enumeration value="World_Craster_Parabolic"/>
+                <xs:enumeration value="World_Cylindrical_Equal_Area"/>
+                <xs:enumeration value="World_Eckert_I"/>
+                <xs:enumeration value="World_Eckert_II"/>
+                <xs:enumeration value="World_Eckert_III"/>
+                <xs:enumeration value="World_Eckert_IV"/>
+                <xs:enumeration value="World_Eckert_V"/>
+                <xs:enumeration value="World_Eckert_VI"/>
+                <xs:enumeration value="World_Equidistant_Conic"/>
+                <xs:enumeration value="World_Equidistant_Cylindrical"/>
+                <xs:enumeration value="World_Flat_Polar_Quartic"/>
+                <xs:enumeration value="World_Gall_Stereographic"/>
+                <xs:enumeration value="World_Hammer_Aitoff"/>
+                <xs:enumeration value="World_Loximuthal"/>
+                <xs:enumeration value="World_Mercator"/>
+                <xs:enumeration value="World_Miller_Cylindrical"/>
+                <xs:enumeration value="World_Mollweide"/>
+                <xs:enumeration value="World_Plate_Carree"/>
+                <xs:enumeration value="World_Polyconic"/>
+                <xs:enumeration value="World_Quartic_Authalic"/>
+                <xs:enumeration value="World_Robinson"/>
+                <xs:enumeration value="World_Sinusoidal"/>
+                <xs:enumeration value="Sphere_Aitoff"/>
+                <xs:enumeration value="Sphere_Behrmann"/>
+                <xs:enumeration value="Sphere_Bonne"/>
+                <xs:enumeration value="Sphere_Craster_Parabolic"/>
+                <xs:enumeration value="Sphere_Cylindrical_Equal_Area"/>
+                <xs:enumeration value="Sphere_Eckert_I"/>
+                <xs:enumeration value="Sphere_Eckert_II"/>
+                <xs:enumeration value="Sphere_Eckert_III"/>
+                <xs:enumeration value="Sphere_Eckert_IV"/>
+                <xs:enumeration value="Sphere_Eckert_V"/>
+                <xs:enumeration value="Sphere_Eckert_VI"/>
+                <xs:enumeration value="Sphere_Equidistant_Conic"/>
+                <xs:enumeration value="Sphere_Equidistant_Cylindrical"/>
+                <xs:enumeration value="Sphere_Flat_Polar_Quartic"/>
+                <xs:enumeration value="Sphere_Gall_Stereographic"/>
+                <xs:enumeration value="Sphere_Hammer_Aitoff"/>
+                <xs:enumeration value="Sphere_Loximuthal"/>
+                <xs:enumeration value="Sphere_Mercator"/>
+                <xs:enumeration value="Sphere_Miller_Cylindrical"/>
+                <xs:enumeration value="Sphere_Mollweide"/>
+                <xs:enumeration value="Sphere_Plate_Carree"/>
+                <xs:enumeration value="Sphere_Polyconic"/>
+                <xs:enumeration value="Sphere_Quartic_Authalic"/>
+                <xs:enumeration value="Sphere_Robinson"/>
+                <xs:enumeration value="Sphere_Sinusoidal"/>
+                <xs:enumeration value="Sphere_Times"/>
+                <xs:enumeration value="Sphere_Van_der_Grinten_I"/>
+                <xs:enumeration value="Sphere_Vertical_Perspective"/>
+                <xs:enumeration value="Sphere_Winkel_I"/>
+                <xs:enumeration value="Sphere_Winkel_II"/>
+                <xs:enumeration value="Sphere_Winkel_Tripel_NGS"/>
+                <xs:enumeration value="The_World_From_Space"/>
+                <xs:enumeration value="World_Times"/>
+                <xs:enumeration value="World_Van_der_Grinten_I"/>
+                <xs:enumeration value="World_Vertical_Perspective"/>
+                <xs:enumeration value="World_Winkel_I"/>
+                <xs:enumeration value="World_Winkel_II"/>
+                <xs:enumeration value="World_Winkel_Tripel_NGS"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
+          <xs:element name="horizCoordSysDef" type="horizCoordSysType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Horizonal Coordinate System Definition</doc:tooltip>
+                <doc:summary>The definition of a coordinate system</doc:summary>
+                <doc:description>Terms and parameters necessary to define a geographic or projected coordinate
+                system for horizonal distances.</doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="vertCoordSys" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Vertical Coordinate System Definition</doc:tooltip>
+              <doc:summary>The reference frame or system from which vertical
+              distances (altitudes or depths) are measured.</doc:summary>
+              <doc:description/>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="altitudeSysDef" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Altitude System Definition</doc:tooltip>
+                    <doc:summary>the reference frame or system from which
+                    altitudes (elevations) are measured.</doc:summary>
+                    <doc:description>The term "altitude"' is used instead of
+                    the common term "elevation" to conform to the terminology
+                    in Federal Information Processing Standards 70-1 and
+                    173.</doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="altitudeDatumName" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Altitude Datum Name</doc:tooltip>
+                          <doc:summary>The identification given to the surface
+                          taken as the surface of reference from which
+                          altitudes are measured.</doc:summary>
+                          <doc:description/>
+                          <doc:example>WGS_datum</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="altitudeResolution" type="res:NonEmptyStringType" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Altitude Resolution</doc:tooltip>
+                          <doc:summary>The minimum distance possible between
+                          two adjacent altitude values, expressed in Altitude
+                          Distance Units of measure.</doc:summary>
+                          <doc:description/>
+                          <doc:example>1</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="altitudeDistanceUnits" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Altitude Distance Units</doc:tooltip>
+                          <doc:summary>Units in which altitude is
+                          measured.</doc:summary>
+                          <doc:description/>
+                          <doc:example>1</doc:example>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="altitudeEncodingMethod" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Altitude Encoding Method</doc:tooltip>
+                          <doc:summary>The means used to encode the
+                          altitudes.</doc:summary>
+                          <doc:description/>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="depthSysDef" minOccurs="0">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Depth System Definition</doc:tooltip>
+                    <doc:summary>The reference frame or system from which
+                    depths are measured.</doc:summary>
+                    <doc:description/>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="depthDatumName" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Depth Datum Name</doc:tooltip>
+                          <doc:summary>The identification given to surface of
+                          reference from which depths are
+                          measured.</doc:summary>
+                          <doc:description/>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="depthResolution" type="res:NonEmptyStringType" maxOccurs="unbounded">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Depth Resolution</doc:tooltip>
+                          <doc:summary>The minimum distance possible between
+                          two adjacent depth values, expressed in Depth
+                          Distance Units of measure.</doc:summary>
+                          <doc:description/>
+
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="depthDistanceUnits" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Depth Distance Units</doc:tooltip>
+                          <doc:summary>The units in which depths are
+                          recorded.</doc:summary>
+                          <doc:description/>
+
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                    <xs:element name="depthEncodingMethod" type="res:NonEmptyStringType">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Depth Encoding Method</doc:tooltip>
+                          <doc:summary>The means used to encode
+                          depths.</doc:summary>
+                          <doc:description/>
+
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="geogCoordSysType">
+    <xs:sequence>
+      <xs:element name="datum">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Datum</doc:tooltip>
+            <doc:summary>The point on the earth representing the origin for the geographic
+            coordinates to which the coorinate system is related to.</doc:summary>
+            <doc:description/>
+            <doc:example>WGS_1984</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="spheroid">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Spheroid</doc:tooltip>
+            <doc:summary>An ellipse that is used to model the earth's surface.</doc:summary>
+            <doc:description>An ellipse is used to define a idealized surface that ignores variation in elevation.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Spheroid name</doc:tooltip>
+                <doc:summary>The name of the spheroid.</doc:summary>
+                <doc:description/>
+                <doc:example>Bessel 1866</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="semiAxisMajor" type="xs:float">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Semi-axis Major</doc:tooltip>
+                <doc:summary>The larger of two orthogonal axes that define the ellipse</doc:summary>
+                <doc:description/>
+                <doc:example>Meter</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="denomFlatRatio" type="xs:float"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="primeMeridian">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Prime Meridian Name</doc:tooltip>
+                <doc:summary>The name of the Prime Meridian</doc:summary>
+                <doc:description/>
+                <doc:example>Greenwich</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="longitude" use="required">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Longitude</doc:tooltip>
+                <doc:summary>The longitude of the Prime Meridian</doc:summary>
+                <doc:description/>
+                <doc:example>0.0</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:restriction base="xs:float">
+                <xs:minInclusive value="-180"/>
+                <xs:maxInclusive value="180"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="unit">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Unit</doc:tooltip>
+            <doc:summary>The unit of angle by which coordinates are expressed.</doc:summary>
+            <doc:description/>
+            <doc:example>degrees</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="angleUnits" use="required">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Unit Name</doc:tooltip>
+                <doc:summary>The name of the unit of measure .</doc:summary>
+                <doc:description/>
+                <doc:example>Degrees</doc:example>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="horizCoordSysType">
+    <xs:choice>
+      <xs:element name="geogCoordSys" type="geogCoordSysType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Geographic Coordinate System</doc:tooltip>
+            <doc:summary>The coodinate system used to express the geographic
+                           coordinates.</doc:summary>
+            <doc:description/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="projCoordSys">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Projected Coordinate System</doc:tooltip>
+            <doc:summary>The coodinate system used to express planar coordinates.</doc:summary>
+            <doc:description/>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="geogCoordSys" type="geogCoordSysType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Geographic Coordinate System</doc:tooltip>
+                  <doc:summary>The coodinate system used to express the geographic
+                           coordinates.</doc:summary>
+                  <doc:description/>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="projection">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Projection</doc:tooltip>
+                  <doc:summary>The method used to tranform between geographic and planar coordinates.
+                  </doc:summary>
+                  <doc:description/>
+                </xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="parameter" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Parameter</doc:tooltip>
+                        <doc:summary>A parameter required by the projection method.</doc:summary>
+                        <doc:description>Most projections require one or more parameters to control the
+                          orientation and positon of the projected coordinate plane.</doc:description>
+                      </xs:appinfo>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Parameter Name</doc:tooltip>
+                            <doc:summary>The name of the parameter.</doc:summary>
+                            <doc:description>If the paramter corresponds to one that has been
+                            defined in the existing eml-SpatialReferenceDictionary, then that name should be
+                            used to enhance recogonizability.</doc:description>
+                            <doc:example>False_Easting</doc:example>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="description" type="xs:string" use="optional">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Parameter Description</doc:tooltip>
+                            <doc:summary>A description of the Parameter.</doc:summary>
+                            <doc:description/>
+                            <doc:example>An offset by which x origin has been adjusted,
+                            expressed in projection units</doc:example>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="value" type="xs:anySimpleType" use="required">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Parameter Value</doc:tooltip>
+                            <doc:summary>The value supplied for the parameter</doc:summary>
+                            <doc:description/>
+                            <doc:example>500000</doc:example>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="unit">
+                    <xs:annotation>
+                      <xs:appinfo>
+                        <doc:tooltip>Projection Unit</doc:tooltip>
+                        <doc:summary>The unit of measure coordinates are expressed in.</doc:summary>
+                        <doc:description/>
+                      </xs:appinfo>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:attribute name="name" type="lengthUnits" use="required">
+                        <xs:annotation>
+                          <xs:appinfo>
+                            <doc:tooltip>Projection Unit Name</doc:tooltip>
+                            <doc:summary>The name of the unit of measure.</doc:summary>
+                            <doc:description/>
+                            <doc:example>Meter</doc:example>
+                          </xs:appinfo>
+                        </xs:annotation>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <doc:tooltip>Projection Name</doc:tooltip>
+                      <doc:summary>The name of the projection method.</doc:summary>
+                      <doc:description>EML does not attempt to document the details
+                      of the particular projection algorithm. It is incumbent on metadata provider
+                      to ensure that the meaning of the names used to identify the method and its parameters will be
+                      as clear as possible.</doc:description>
+                      <doc:example>Transverse_Mercator</doc:example>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:element name="projectionList">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="horizCoordSysDef" type="horizCoordSysType" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Horizonal Coordinate System Definition</doc:tooltip>
+              <doc:summary>The definition of a coordinate system</doc:summary>
+              <doc:description>Terms and parameters necessary to define a geographic or projected coordinate
+                system for horizonal distances.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="spatialReference" type="SpatialReferenceType"/>
+  <xs:simpleType name="lengthUnits">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="meter"/>
+      <xs:enumeration value="nanometer"/>
+      <xs:enumeration value="micrometer"/>
+      <xs:enumeration value="micron"/>
+      <xs:enumeration value="millimeter"/>
+      <xs:enumeration value="centimeter"/>
+      <xs:enumeration value="decimeter"/>
+      <xs:enumeration value="dekameter"/>
+      <xs:enumeration value="hectometer"/>
+      <xs:enumeration value="kilometer"/>
+      <xs:enumeration value="megameter"/>
+      <xs:enumeration value="angstrom"/>
+      <xs:enumeration value="inch"/>
+      <xs:enumeration value="Foot_US"/>
+      <xs:enumeration value="foot"/>
+      <xs:enumeration value="Foot_Gold_Coast"/>
+      <xs:enumeration value="fathom"/>
+      <xs:enumeration value="nauticalMile"/>
+      <xs:enumeration value="yard"/>
+      <xs:enumeration value="Yard_Indian"/>
+      <xs:enumeration value="Link_Clarke"/>
+      <xs:enumeration value="Yard_Sears"/>
+      <xs:enumeration value="mile"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="angleUnits">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="radian"/>
+      <xs:enumeration value="degree"/>
+      <xs:enumeration value="grad"/>
+      <xs:enumeration value="degree"/>
+      <xs:enumeration value="grad"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-spatialVector.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-spatialVector.xsd
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+    xmlns:con="eml://ecoinformatics.org/constraint-2.1.1" 
+    xmlns:att="eml://ecoinformatics.org/attribute-2.1.1" 
+    xmlns:spref="eml://ecoinformatics.org/spatialReference-2.1.1" 
+    xmlns:ent="eml://ecoinformatics.org/entity-2.1.1" 
+    xmlns="eml://ecoinformatics.org/spatialVector-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/spatialVector-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/spatialReference-2.1.1" 
+  schemaLocation="eml-spatialReference.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/entity-2.1.1" 
+  schemaLocation="eml-entity.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+  schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/attribute-2.1.1" 
+  schemaLocation="eml-attribute.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/constraint-2.1.1" 
+  schemaLocation="eml-constraint.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+    '$RCSfile: eml-spatialVector.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.43 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-spatialVector</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>
+              The eml-spatialVector module - Logical information about
+              non-gridded geospatial image data
+            </title>
+            <para>
+              The eml-spatialVector module allows for the description of
+              spatial objects in a GIS system that are not defined in a
+              regularly gridded pattern.  These geometries include points and
+              vectors and the relationships among them.  Specific attributes of
+              a spatial vector can be documented here including the vector's
+              geometry type, count and topology level.
+            </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all spatial datasets that contain spatial data
+        entities represented as vector features.</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="spatialVector" type="SpatialVectorType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Spatial Vector</doc:tooltip>
+        <doc:summary>Description of a spatial data entity based on features
+        represented by vectors</doc:summary>
+        <doc:description>Description of a spatial data entity based on features
+        represented by vectors</doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="SpatialVectorType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Spatial Vector Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="ent:EntityGroup"/>
+        <xs:element name="attributeList" type="att:AttributeListType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute List</doc:tooltip>
+              <doc:summary>The list of attributes associated with this
+              entity.</doc:summary>
+              <doc:description>The list of attributes associated with this
+              entity.  For more information see the eml-attribute
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="constraint" type="con:ConstraintType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Constraint</doc:tooltip>
+              <doc:summary>Description of any relational constraints on 
+              this entity.</doc:summary>
+              <doc:description>Description of any relational constraints on 
+              this entity.  For more information see the eml-constraint
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="geometry" type="GeometryType" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Geometry</doc:tooltip>
+              <doc:summary>Type of geometric feature(s) represented in the
+              entity.</doc:summary>
+              <doc:description>Geometric feature classification is based on an
+              enumeration of simple feature classes defined by the OpenGIS
+              consortium and implemented in Geographic Markup Language as
+              simple feature types.</doc:description>
+              <doc:example>polygon</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="geometricObjectCount" type="res:NonEmptyStringType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Geometric Object Count</doc:tooltip>
+              <doc:summary>Total number of the geometric objects
+              occurring in the dataset.</doc:summary>
+              <doc:description>Total number of the geometric objects
+              occurring in the dataset.</doc:description>
+              <doc:example>24</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="topologyLevel" type="TopologyLevel" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Topology Level</doc:tooltip>
+              <doc:summary>Code which identifies the degree of
+              complexity.</doc:summary>
+              <doc:description>This element describes the relative complexity
+              of the geometric information in the data file.</doc:description>
+              <doc:example>geometryOnly</doc:example>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="spatialReference" type="spref:SpatialReferenceType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Spatial Reference</doc:tooltip>
+              <doc:summary/>
+              <doc:description/>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="horizontalAccuracy" type="DataQuality" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Horizontal Accuracy</doc:tooltip>
+              <doc:summary>Horizontal positional accuracy of the data</doc:summary>
+              <doc:description>Horizontal positional accuracy of the data
+              expressed as either text or quantitative assessment.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="verticalAccuracy" type="DataQuality" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Vertical Accuracy</doc:tooltip>
+              <doc:summary>Vertical positional accuracy of the data</doc:summary>
+              <doc:description>Vertical positional accuracy of the data
+              expressed as either text or quantitative assessment.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:simpleType name="GeometryType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Geometry Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Point"/>
+      <xs:enumeration value="LineString"/>
+      <xs:enumeration value="LinearRing"/>
+      <xs:enumeration value="Polygon"/>
+      <xs:enumeration value="MultiPoint"/>
+      <xs:enumeration value="MultiLineString"/>
+      <xs:enumeration value="MultiPolygon"/>
+      <xs:enumeration value="MultiGeometry"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TopologyLevel">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Topology Level Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="geometryOnly"/>
+      <xs:enumeration value="nonPlanarGraph"/>
+      <xs:enumeration value="planarLineGraph"/>
+      <xs:enumeration value="fullPlanarGraph"/>
+      <xs:enumeration value="surfaceGraph"/>
+      <xs:enumeration value="fullTopology3D"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DataQuality">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Data Quality Type</doc:tooltip>
+        <doc:summary/>
+        <doc:description/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="accuracyReport" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Accuracy Report</doc:tooltip>
+            <doc:summary>A qualitative statement about the accuracy of the data.</doc:summary>
+            <doc:description>A text statement of the data quality, included the means by which it was determined.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="quantitativeAccuracyReport" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Quantitative Accuracy Report</doc:tooltip>
+            <doc:summary>A quantitative assessment of the data quality.</doc:summary>
+            <doc:description>A quantitative assessment of the data quality expressed as a value and 
+            the method of its determination.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="quantitativeAccuracyValue" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Quantitative Accuracy Value</doc:tooltip>
+                  <doc:summary>The value resulting from the accuracy test.</doc:summary>
+                  <doc:description>The value resulting from the accuracy test. Typically, this will be expressed
+                  in units corresponding to those declared for the parameter being assessed.</doc:description>
+                  <doc:example>4.5</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="quantitativeAccuracyMethod" type="res:NonEmptyStringType">
+              <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>Quantitative Accuracy Method</doc:tooltip>
+                  <doc:summary>The method used to calculate the accuracy value.</doc:summary>
+                  <doc:description>Identification and explanation of the method used to calculate the quantitative 
+                  accuracy assessment.</doc:description>
+                  <doc:example>Error expressed as root mean square of 5 control points. </doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-storedProcedure.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-storedProcedure.xsd
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns="eml://ecoinformatics.org/storedProcedure-2.1.1" 
+    xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" 
+    xmlns:prot="eml://ecoinformatics.org/protocol-2.1.1" 
+    xmlns:phys="eml://ecoinformatics.org/physical-2.1.1" 
+    xmlns:att="eml://ecoinformatics.org/attribute-2.1.1" 
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+    xmlns:ent="eml://ecoinformatics.org/entity-2.1.1" 
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+    xmlns:con="eml://ecoinformatics.org/constraint-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/storedProcedure-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/entity-2.1.1" 
+  schemaLocation="eml-entity.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/attribute-2.1.1" 
+  schemaLocation="eml-attribute.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/protocol-2.1.1" 
+  schemaLocation="eml-protocol.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/physical-2.1.1" 
+  schemaLocation="eml-physical.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" 
+  schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+  schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/constraint-2.1.1" 
+  schemaLocation="eml-constraint.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-storedProcedure.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.46 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-storedProcedure</doc:moduleName>
+        <doc:moduleDescription>
+        <section xmlns="">
+          <title>
+            The eml-storedProcedure module - Data tables
+            resulting from procedures stored in a database
+          </title>
+          <para>
+            The storedProcedure module is meant to capture information on
+            procedures that produce data output in the form of a data table.
+            In an RDBMS one can code complex queries and transactions into
+            stored procedures and then invoke them directly from front-end
+            applications. It allows the optional description of any parameters
+            that are expected to be passed to the procedure when it is called.
+          </para>
+        </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>Use the storedProcedure module to document
+        datasets that use storedProcedures to retrieve archived
+        data.</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="storedProcedure" type="StoredProcedureType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Stored Procedure&gt;</doc:tooltip>
+        <doc:summary>The storedProcedure element documents stored
+        procedures.</doc:summary>
+        <doc:description>The storedProcedure element is meant to capture
+        information on procedures that produce data output in the form of a
+        data table. In an RDBMS one can code complex queries and transactions
+        into stored procedures and then invoke them directly from front-end
+        applications. This element allows the optional description of any
+        parameters that are expected to be passed to the procedure when it is
+        called. A common use of a stored procedure is to rotate a data table 
+        from attributes in columns to attributes in rows for statistical 
+        analysis.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="StoredProcedureType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Stored Procedure complex type&gt;</doc:tooltip>
+        <doc:summary>Structure for documenting a stored procedure</doc:summary>
+        <doc:description>The StoredProcedureType complex type defines the structure
+        for documenting a stored procedure.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="ent:EntityGroup"/>
+        <xs:element name="attributeList" type="att:AttributeListType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute List</doc:tooltip>
+              <doc:summary>The list of attributes associated with this
+              entity.</doc:summary>
+              <doc:description>The list of attributes associated with this
+              entity.  For more information see the eml-attribute
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="constraint" type="con:ConstraintType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Constraint</doc:tooltip>
+              <doc:summary/>
+              <doc:description>Description of any relational constraints on '
+              this entity.  For more information see the eml-constraint
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Parameter</doc:tooltip>
+              <doc:summary>A parameter that is required as input to the
+              stored procedure.</doc:summary>
+              <doc:description>The parameter elements defines the fields that
+              may be required to invoke a stored procedure.</doc:description>
+              
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+  <xs:complexType name="ParameterType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Parameter complex type</doc:tooltip>
+        <doc:summary>The structure for defining a parameter that is required as
+        input to the stored procedure.</doc:summary>
+        <doc:description>The parameter complex type defines the structure for
+        documenting the parameters that may be required to invoke a stored
+        procedure.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="name" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Parameter Name</doc:tooltip>
+            <doc:summary>The name of the parameter.</doc:summary>
+            <doc:description>The value of the name field is the name of the
+            parameter.</doc:description>
+            <doc:example>SiteID</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="domainDescription" type="res:NonEmptyStringType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Domain Description</doc:tooltip>
+            <doc:summary>A description of domain of valid values for the
+            parameter.</doc:summary>
+            <doc:description>The domainDescription field is used to describe
+            the valid entries for the parameter being described. A stored
+            procedure will work only when the parameter's value corresponds to
+            an actual value in a database.</doc:description>
+            <doc:example>The database has SiteId values that range from cap1 to
+            cap10, however the allowable SiteId values for this stored procedure
+            are cap1,cap2,cap4 or cap7. </doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="required" type="xs:boolean">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Required</doc:tooltip>
+            <doc:summary>Whether or not the parameter is
+            required.</doc:summary>
+            <doc:description>The required field is used to document whether the
+            parameter being described is or is not required when invoking the
+            stored procedure.</doc:description>
+            <doc:example>true</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="repeats" type="xs:boolean">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Repeats</doc:tooltip>
+            <doc:summary>Whether or not the parameter repeats.</doc:summary>
+            <doc:description>The repeats field is used to document whether or
+            not the parameter being described can be repeated when invoking the
+            stored procedure.</doc:description>
+            <doc:example>true</doc:example>
+            
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-text.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-text.xsd
@@ -1,0 +1,473 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns="eml://ecoinformatics.org/text-2.1.1"
+    xmlns:txt="eml://ecoinformatics.org/text-2.1.1"
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1"
+    targetNamespace="eml://ecoinformatics.org/text-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1"
+  	schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" 
+  	schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-text.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2009-02-25 23:51:54 $'
+      '$Revision: 1.23 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-text</doc:moduleName>
+        <doc:moduleDescription>
+        <section xmlns="">
+          <title>The eml-text module - Text field formatting</title>
+          <para>
+          The eml-text module is a wrapper container that allows general
+            text descriptions to be used within the various modules of eml.
+            It can include either structured or unstructured text blocks.
+            It isn't really appropriate to use this module outside of the
+            context of a parent module, because the parent module determines
+            the appropriate context to which this text description applies.
+            The eml-text module allows one to provide structure to a text
+            description in order to convey concepts such as sections
+            (paragraphs), hierarchy (ordered and unordered lists), emphasis
+            (bold, superscript, subscript) etc.  The structured elements
+            are a subset of <ulink url="http://www.docbook.org">DocBook</ulink>
+            so the predefined DocBook stylesheets can be used to style
+            EML fields that implement this module.
+          </para>
+        </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>any module</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="text" type="TextType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Text</doc:tooltip>
+        <doc:summary>A simple text desription.</doc:summary>
+        <doc:description>The "text" element allows for both formatted and
+        unformatted text blocks to be included in EML. It can contain a number
+        of relevant subsections that allow the use of titles, sections, and
+        paragraphs in the text block. This markup is a subset of DocBook.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  
+  <xs:complexType name="TextType" mixed="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Text</doc:tooltip>
+        <doc:summary>A simple text desription.</doc:summary>
+        <doc:description>The "text" element allows for both formatted and
+        unformatted text blocks to be included in EML. It can contain a number
+        of relevant subsections that allow the use of titles, sections, and
+        paragraphs in the text block. This markup is a subset of DocBook.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="section" type="SectionType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Section</doc:tooltip>
+            <doc:summary>A section of related text.</doc:summary>
+            <doc:description>The "section" element allows for
+            grouping related paragraphs of text together, with
+            an optional title.  This markup is a subset of DocBook.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="para" type="ParagraphType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Paragraph</doc:tooltip>
+            <doc:summary>A simple paragraph of text.</doc:summary>
+            <doc:description>The "paragraph" element allows for
+            both formatted and unformatted text blocks to be included
+            in EML. It can be plain text or text with a limited set of
+            markup tags, including emphasis, subscript,
+            superscript, and lists. This markup is a subset of DocBook.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute ref="xml:lang"/>
+  </xs:complexType>
+  
+  <xs:complexType name="ParagraphType" mixed="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Paragraph</doc:tooltip>
+        <doc:summary>A simple paragraph of text.</doc:summary>
+        <doc:description>The "paragraph" element allows for
+        both formatted and unformatted text blocks to be included
+        in EML. It can be plain text or text with a limited set of
+        markup tags, including emphasis, subscript,
+        superscript, lists and links. This markup is a subset of DocBook.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+		<xs:element name="value" type="i18nString" minOccurs="0" maxOccurs="unbounded">
+	        <xs:annotation>
+	          <xs:appinfo>
+	            <doc:tooltip>Localized string for the paragraph</doc:tooltip>
+	            <doc:summary>Language translation for the paragraph</doc:summary>
+	            <doc:description>Language translation as specified by the xml:lang attribute</doc:description>
+	          </xs:appinfo>
+			</xs:annotation>
+		</xs:element>
+      <xs:element name="itemizedlist" type="ListType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Itemized List</doc:tooltip>
+            <doc:summary>A list of items in a text paragraph.
+            </doc:summary>
+            <doc:description>A list of items in a text paragraph.  The
+            list is generally displayed as a bulleted list.
+            This markup is a subset of DocBook.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="orderedlist" type="ListType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Ordered List</doc:tooltip>
+            <doc:summary>An ordered list of items in a text paragraph.
+            </doc:summary>
+            <doc:description>An ordered list of items in a text
+            paragraph.  The list is generally displayed as a numbered
+            list. This markup is a subset of DocBook.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="emphasis">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Emphasis</doc:tooltip>
+            <doc:summary>A span of emphasized text in a paragraph.</doc:summary>
+            <doc:description>A span of emphasized text in a paragraph.
+             Emphasized text is generally rendered as boldfaced or otherwise
+             distinct from the surrounding text.
+             This markup is a subset of DocBook.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+        	<xs:sequence>
+        		<xs:element name="value" type="i18nString" minOccurs="0" maxOccurs="unbounded"/>
+        	</xs:sequence>
+        	<xs:attribute ref="xml:lang"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="subscript" type="SubSuperScriptType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Subscript</doc:tooltip>
+            <doc:summary>A subscript in a text paragraph.</doc:summary>
+            <doc:description>A subscript in a text paragraph.
+             This markup is a subset of DocBook.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="superscript" type="SubSuperScriptType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Superscript</doc:tooltip>
+            <doc:summary>A superscript in a text paragraph.</doc:summary>
+            <doc:description>A superscript in a text paragraph.
+             This markup is a subset of DocBook.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="literalLayout">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>literalLayout</doc:tooltip>
+            <doc:summary>The equivalent to &lt;pre&gt; in html.</doc:summary>
+            <doc:description>This element specifies that the structure of
+            the text within the tag, specifically the whitespace, should not
+            be altered.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+        	<xs:sequence>
+        		<xs:element name="value" type="i18nString" minOccurs="0" maxOccurs="unbounded"/>
+        	</xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ulink" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>ulink</doc:tooltip>
+            <doc:summary>a link that addresses its target by means of a URL</doc:summary>
+            <doc:description>this element and its children allow paragraphs to contain
+              urls and titles for anchor tags. This markup is a subset of DocBook.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="citetitle" type="i18nString">
+                 <xs:annotation>
+                <xs:appinfo>
+                  <doc:tooltip>citetitle</doc:tooltip>
+                  <doc:summary>the title of the cited work</doc:summary>
+                  <doc:description>the citetitle element  contains a text title for the url. It can be displayed in an anchor tag. This markup is a subset of DocBook.</doc:description>
+                  <doc:example>The Dublin Core Metadata Initiative</doc:example>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="url" use="optional">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>url</doc:tooltip>
+                <doc:summary>the Uniform Resource Locator for the cited work</doc:summary>
+                <doc:description>the url attribute contains the location of the work for a link. This markup is a subset of DocBook.</doc:description>
+                <doc:example>url="http://dublincore.org/documents/usageguide/"</doc:example>
+              </xs:appinfo>
+            </xs:annotation>            
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute ref="xml:lang"/>
+  </xs:complexType>
+  
+  <xs:complexType name="SectionType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Section</doc:tooltip>
+        <doc:summary>A section of related text.</doc:summary>
+        <doc:description>The "section" element allows for
+        grouping related paragraphs (or other sections) of text together, with
+        an optional title.  This markup is a subset of DocBook.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="title" type="i18nString" minOccurs="0">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Title</doc:tooltip>
+            <doc:summary>The optional title of the section.</doc:summary>
+            <doc:description>The optional title for a section.
+            This markup is a subset of DocBook.
+            </doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="para" type="ParagraphType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Paragraph</doc:tooltip>
+              <doc:summary>A simple paragraph of text.</doc:summary>
+              <doc:description>The "paragraph" element allows for
+              both formatted and unformatted text blocks to be included
+              in EML. It can be plain text or text with a limited set of
+              markup tags, including emphasis, subscript,
+              superscript, and lists. This markup is a subset of DocBook.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="section" type="SectionType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Section</doc:tooltip>
+              <doc:summary>A section of related text.</doc:summary>
+              <doc:description>The "section" element allows for
+              grouping related paragraphs of text together, with
+              an optional title.  This markup is a subset of DocBook.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute ref="xml:lang"/>
+  </xs:complexType>
+  
+  <xs:complexType name="ListType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>ListType</doc:tooltip>
+        <doc:summary>A list of items in a text paragraph.</doc:summary>
+        <doc:description>A list of items in a text paragraph.  The ListType
+        is used by both orderedlist elements and itemizedlist elements.
+        This markup is a subset of DocBook.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+        <xs:element name="listitem" minOccurs="1" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>List Item</doc:tooltip>
+              <doc:summary>An item in a list of items.</doc:summary>
+              <doc:description>An item in a list of items.  Each list item
+              is formatted as a bulleted or numbered item depending on the
+              list type in which it resides. List items contain paragraphs
+              which in turn can be plain text or text with a limited set of
+              markup tags, including emphasis, subscript,
+              superscript, and lists. This markup is a subset of DocBook.
+              </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+              <xs:element name="para" type="ParagraphType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Paragraph</doc:tooltip>
+                    <doc:summary>A simple paragraph of text.</doc:summary>
+                    <doc:description>The "paragraph" element allows for
+                    both formatted and unformatted text blocks to be included
+                    in EML. It can be plain text or text with a limited set of
+                    markup tags, including emphasis, subscript,
+                    superscript, and lists. This markup is a subset of DocBook.
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="itemizedlist" type="ListType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Itemized List</doc:tooltip>
+                    <doc:summary>A list of items in a text paragraph.
+                    </doc:summary>
+                    <doc:description>A list of items in a text paragraph.  The
+                    list is generally displayed as a bulleted list.
+                    This markup is a subset of DocBook.
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="orderedlist" type="ListType">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Ordered List</doc:tooltip>
+                    <doc:summary>An ordered list of items in a text paragraph.
+                    </doc:summary>
+                    <doc:description>An ordered list of items in a text
+                    paragraph.  The list is generally displayed as a numbered
+                    list. This markup is a subset of DocBook.
+                    </doc:description>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="SubSuperScriptType" mixed="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Subscript/Superscript Type</doc:tooltip>
+        <doc:summary>A subscript or a superscript in a text paragraph.
+        </doc:summary>
+        <doc:description>A subscript or a superscript in a text paragraph.
+        This type is used by both subscript and superscript elements to define
+        their recursive content. This markup is a subset of DocBook.
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+    	<xs:element name="value" type="i18nString" minOccurs="0" maxOccurs="unbounded">
+	        <xs:annotation>
+	          <xs:appinfo>
+	            <doc:tooltip>Localized string for the sub/superscript</doc:tooltip>
+	            <doc:summary>Language translation for the sub/superscript</doc:summary>
+	            <doc:description>Language translation as specified by the xml:lang attribute</doc:description>
+	          </xs:appinfo>
+			</xs:annotation>
+		</xs:element>
+      <xs:element name="subscript" type="SubSuperScriptType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Subscript</doc:tooltip>
+            <doc:summary>A subscript in a text paragraph.</doc:summary>
+            <doc:description>A subscript in a text paragraph.
+             This markup is a subset of DocBook.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="superscript" type="SubSuperScriptType">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Superscript</doc:tooltip>
+            <doc:summary>A superscript in a text paragraph.</doc:summary>
+            <doc:description>A superscript in a text paragraph.
+             This markup is a subset of DocBook.</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:choice>
+    <xs:attribute ref="xml:lang"/>
+  </xs:complexType>
+  
+	<xs:complexType name="i18nString">
+		<xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Localized string</doc:tooltip>
+            <doc:summary>Language translation for the text</doc:summary>
+            <doc:description>Language translation as specified by the xml:lang attribute</doc:description>
+          </xs:appinfo>
+        </xs:annotation>
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute ref="xml:lang">
+					<xs:annotation>
+		              <xs:appinfo>
+		                <doc:tooltip>xml:lang</doc:tooltip>
+		                <doc:summary>language code for element content</doc:summary>
+		                <doc:description>Specifies the language</doc:description>
+		                <doc:example>xml:lang="en-US"</doc:example>
+		              </xs:appinfo>
+		            </xs:annotation> 
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-unitTypeDefinitions.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-unitTypeDefinitions.xsd
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" xmlns:unit="eml://ecoinformatics.org/units-2.1.1" targetNamespace="eml://ecoinformatics.org/units-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-unitTypeDefinitions</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title>EML Unit Type Definitions</title>
+            <section>
+              <title>Philosophy of Units</title>
+              <para>The concept of "unit" represents one of the most fundamental
+            categories of metadata. The classic example of data entropy is the
+            case in which a reported numeric value loses meaning due to lack of
+            associated units. Much of Ecology is driven by measurement, and
+            most measurements are inherently comparative. Good data description
+            requires a representation of the basis for comparison, i.e., the
+            unit. In modeling units, the authors of EML drew
+            inspiration from the
+            <ulink url="http://physics.nist.gov/cuu/Units/introduction.html">
+            NIST Reference on Constants, Units, and Uncertainty</ulink>.
+            This document defines a unit as "a particular physical quantity,
+            defined and adopted by convention, with which other particular
+            quantities of the same kind are compared to express their value."
+            The authors of the EML 2 specification (hereafter "the authors")
+            decided to make the unit element required, wherever
+            possible.</para>
+              <para>The units are defined in the 
+        <ulink url="http://www.ch.ic.ac.uk/rzepa/codata2/">STMML language</ulink> 
+        in a document that is shipped with each release of
+        EML. See the accompanying STMML file, eml-unitDictionary.xml, for
+        precise, quantitative definitions of each of these units and their
+        relationships to base SI units</para>
+              <para>which modules use these types (and which could but dont yet?)</para>
+              <para>anything else?</para>
+            </section>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>any module that needs units</doc:recommendedUsage>
+        <doc:standAlone>no</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <!-- 
+
+
+the dictionary of all the units -->
+  <xs:simpleType name="StandardUnitDictionary">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Standard Units</doc:tooltip>
+        <doc:summary>The enumerated list of standard units, mainly S unitsI</doc:summary>
+        <doc:description>
+          <para>The unitDictionary is the standard set
+        of units included with the EML distribution, mainly from the
+        SI standard. These unit names should  be used in the standardUnit field to
+        describe an attribute. See the accompanying STMML file, eml-unitDictionary.xml, for
+        precise, quantitative definitions of each of these units and their
+        relationships to base SI units.</para>
+          <para>The standard Unit Dictionary is built from a union of simpleTypes. 
+          This construct allows unit types to be used individually as appropriate 
+          in EML content (e.g., LengthUnitType for distances )</para>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:union memberTypes="unit:LengthUnitType unit:MassUnitType unit:otherUnitType"/>
+  </xs:simpleType>
+  <!-- 
+
+length units -->
+  <xs:simpleType name="LengthUnitType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Length Units</doc:tooltip>
+        <doc:summary>The  list of units which are of length type, or have a parentSI of meter
+        SI</doc:summary>
+        <doc:description>
+          <para>The LengthUnitType is the enumerated list of units which are of length type, or have a parentSI of meter. 
+        These unit names can be used where ever content should be restricted to a length, such as a distance or 
+        altitude. The units are defined in the STMML
+        language in a document that is shipped with each release of
+        EML called  eml-unitDictionary.xml. See this file for
+        precise, quantitative definitions of each of these units and their
+        relationships to base SI units.</para>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="meter"/>
+      <xs:enumeration value="nanometer"/>
+      <xs:enumeration value="micrometer"/>
+      <xs:enumeration value="micron"/>
+      <xs:enumeration value="millimeter"/>
+      <xs:enumeration value="centimeter"/>
+      <xs:enumeration value="decimeter"/>
+      <xs:enumeration value="dekameter"/>
+      <xs:enumeration value="hectometer"/>
+      <xs:enumeration value="kilometer"/>
+      <xs:enumeration value="megameter"/>
+      <xs:enumeration value="angstrom"/>
+      <xs:enumeration value="inch"/>
+      <xs:enumeration value="Foot_US"/>
+      <xs:enumeration value="foot"/>
+      <xs:enumeration value="Foot_Gold_Coast"/>
+      <xs:enumeration value="fathom"/>
+      <xs:enumeration value="nauticalMile"/>
+      <xs:enumeration value="yard"/>
+      <xs:enumeration value="Yard_Indian"/>
+      <xs:enumeration value="Link_Clarke"/>
+      <xs:enumeration value="Yard_Sears"/>
+      <xs:enumeration value="mile"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <!-- 
+
+
+mass units -->
+  <xs:simpleType name="MassUnitType">
+     <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Mass Units</doc:tooltip>
+        <doc:summary>The  list of units which are of mass type, or have a parentSI of kilogram
+        </doc:summary>
+        <doc:description>
+          <para>The MassUnitType is the enumerated list of units which are of mass type, or have a parentSI of kilogram. 
+        These unit names can be used where ever content should be restricted to a mass, such as an amount. 
+        The units are defined in the STMML
+        language in a document that is shipped with each release of
+        EML called  eml-unitDictionary.xml. See this file for
+        precise, quantitative definitions of each of these units and their
+        relationships to base SI units.</para>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="kilogram"/>
+      <xs:enumeration value="nanogram"/>
+      <xs:enumeration value="microgram"/>
+      <xs:enumeration value="milligram"/>
+      <xs:enumeration value="centigram"/>
+      <xs:enumeration value="decigram"/>
+      <xs:enumeration value="gram"/>
+      <xs:enumeration value="dekagram"/>
+      <xs:enumeration value="hectogram"/>
+      <xs:enumeration value="megagram"/>
+      <xs:enumeration value="tonne"/>
+      <xs:enumeration value="pound"/>
+      <xs:enumeration value="ton"/>
+    </xs:restriction>
+  </xs:simpleType>
+ 
+  <!-- 
+
+
+the other units, not previously described -->
+  <xs:simpleType name="otherUnitType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Other Standard Units</doc:tooltip>
+        <doc:summary>The enumerated list of standard units that are not 
+        included in the any other named simpleType</doc:summary>
+        <doc:description>
+          <para>The unitDictionary is the standard set
+        of units included with the EML distribution, mainly from the
+        SI standard. These unit names can be used in the standardUnit field to
+        describe an attribute. The units are defined in the STMML
+        language in a document that is shipped with each release of
+        EML. See the accompanying STMML file eml-unitDictionary.xml for
+        precise, quantitative definitions of each of these units and their
+        relationships to base SI units.</para>
+          <para>The standard Unit Dictionary is built from a union of simpleTypes. This Type 
+enumerates the units which are not in other Type definitions, but are to be 
+included as standard.</para>
+        </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dimensionless"/>
+      <xs:enumeration value="second"/>
+      <xs:enumeration value="kelvin"/>
+      <xs:enumeration value="coulomb"/>
+      <xs:enumeration value="ampere"/>
+      <xs:enumeration value="mole"/>
+      <xs:enumeration value="candela"/>
+      <xs:enumeration value="number"/>
+    <xs:enumeration value="radian"/>
+      <xs:enumeration value="degree"/>
+      <xs:enumeration value="grad"/>   
+      <xs:enumeration value="cubicMeter"/>
+      <xs:enumeration value="nominalMinute"/>
+      <xs:enumeration value="nominalHour"/>
+      <xs:enumeration value="nominalDay"/>
+      <xs:enumeration value="nominalWeek"/>
+      <xs:enumeration value="nominalYear"/>
+      <xs:enumeration value="nominalLeapYear"/>
+      <xs:enumeration value="celsius"/>
+      <xs:enumeration value="fahrenheit"/>
+      <xs:enumeration value="nanosecond"/>
+      <xs:enumeration value="microsecond"/>
+      <xs:enumeration value="millisecond"/>
+      <xs:enumeration value="centisecond"/>
+      <xs:enumeration value="decisecond"/>
+      <xs:enumeration value="dekasecond"/>
+      <xs:enumeration value="hectosecond"/>
+      <xs:enumeration value="kilosecond"/>
+      <xs:enumeration value="megasecond"/>
+      <xs:enumeration value="minute"/>
+      <xs:enumeration value="hour"/>
+      <xs:enumeration value="kiloliter"/>
+      <xs:enumeration value="microliter"/>
+      <xs:enumeration value="milliliter"/>
+      <xs:enumeration value="liter"/>
+      <xs:enumeration value="gallon"/>
+      <xs:enumeration value="quart"/>
+      <xs:enumeration value="bushel"/>
+      <xs:enumeration value="cubicInch"/>
+      <xs:enumeration value="pint"/>
+      <xs:enumeration value="megahertz"/>
+      <xs:enumeration value="kilohertz"/>
+      <xs:enumeration value="hertz"/>
+      <xs:enumeration value="millihertz"/>
+      <xs:enumeration value="newton"/>
+      <xs:enumeration value="joule"/>
+      <xs:enumeration value="calorie"/>
+      <xs:enumeration value="britishThermalUnit"/>
+      <xs:enumeration value="footPound"/>
+      <xs:enumeration value="lumen"/>
+      <xs:enumeration value="lux"/>
+      <xs:enumeration value="becquerel"/>
+      <xs:enumeration value="gray"/>
+      <xs:enumeration value="sievert"/>
+      <xs:enumeration value="katal"/>
+      <xs:enumeration value="henry"/>
+      <xs:enumeration value="megawatt"/>
+      <xs:enumeration value="kilowatt"/>
+      <xs:enumeration value="watt"/>
+      <xs:enumeration value="milliwatt"/>
+      <xs:enumeration value="megavolt"/>
+      <xs:enumeration value="kilovolt"/>
+      <xs:enumeration value="volt"/>
+      <xs:enumeration value="millivolt"/>
+      <xs:enumeration value="farad"/>
+      <xs:enumeration value="ohm"/>
+      <xs:enumeration value="ohmMeter"/>
+      <xs:enumeration value="siemen"/>
+      <xs:enumeration value="weber"/>
+      <xs:enumeration value="tesla"/>
+      <xs:enumeration value="pascal"/>
+      <xs:enumeration value="megapascal"/>
+      <xs:enumeration value="kilopascal"/>
+      <xs:enumeration value="atmosphere"/>
+      <xs:enumeration value="bar"/>
+      <xs:enumeration value="millibar"/>
+      <xs:enumeration value="kilogramsPerSquareMeter"/>
+      <xs:enumeration value="gramsPerSquareMeter"/>
+      <xs:enumeration value="milligramsPerSquareMeter"/>
+      <xs:enumeration value="kilogramsPerHectare"/>
+      <xs:enumeration value="tonnePerHectare"/>
+      <xs:enumeration value="poundsPerSquareInch"/>
+      <xs:enumeration value="kilogramPerCubicMeter"/>
+      <xs:enumeration value="milliGramsPerMilliLiter"/>
+      <xs:enumeration value="gramsPerLiter"/>
+      <xs:enumeration value="milligramsPerCubicMeter"/>
+      <xs:enumeration value="microgramsPerLiter"/>
+      <xs:enumeration value="milligramsPerLiter"/>
+      <xs:enumeration value="gramsPerCubicCentimeter"/>
+      <xs:enumeration value="gramsPerMilliliter"/>
+      <xs:enumeration value="gramsPerLiterPerDay"/>
+      <xs:enumeration value="litersPerSecond"/>
+      <xs:enumeration value="cubicMetersPerSecond"/>
+      <xs:enumeration value="cubicFeetPerSecond"/>
+      <xs:enumeration value="squareMeter"/>
+      <xs:enumeration value="are"/>
+      <xs:enumeration value="hectare"/>
+      <xs:enumeration value="squareKilometers"/>
+      <xs:enumeration value="squareMillimeters"/>
+      <xs:enumeration value="squareCentimeters"/>
+      <xs:enumeration value="acre"/>
+      <xs:enumeration value="squareFoot"/>
+      <xs:enumeration value="squareYard"/>
+      <xs:enumeration value="squareMile"/>
+      <xs:enumeration value="litersPerSquareMeter"/>
+      <xs:enumeration value="bushelsPerAcre"/>
+      <xs:enumeration value="litersPerHectare"/>
+      <xs:enumeration value="squareMeterPerKilogram"/>
+      <xs:enumeration value="metersPerSecond"/>
+      <xs:enumeration value="metersPerDay"/>
+      <xs:enumeration value="feetPerDay"/>
+      <xs:enumeration value="feetPerSecond"/>
+      <xs:enumeration value="feetPerHour"/>
+      <xs:enumeration value="yardsPerSecond"/>
+      <xs:enumeration value="milesPerHour"/>
+      <xs:enumeration value="milesPerSecond"/>
+      <xs:enumeration value="milesPerMinute"/>
+      <xs:enumeration value="centimetersPerSecond"/>
+      <xs:enumeration value="millimetersPerSecond"/>
+      <xs:enumeration value="centimeterPerYear"/>
+      <xs:enumeration value="knots"/>
+      <xs:enumeration value="kilometersPerHour"/>
+      <xs:enumeration value="metersPerSecondSquared"/>
+      <xs:enumeration value="waveNumber"/>
+      <xs:enumeration value="cubicMeterPerKilogram"/>
+      <xs:enumeration value="cubicMicrometersPerGram"/>
+      <xs:enumeration value="amperePerSquareMeter"/>
+      <xs:enumeration value="amperePerMeter"/>
+      <xs:enumeration value="molePerCubicMeter"/>
+      <xs:enumeration value="molarity"/>
+      <xs:enumeration value="molality"/>
+      <xs:enumeration value="candelaPerSquareMeter"/>
+      <xs:enumeration value="metersSquaredPerSecond"/>
+      <xs:enumeration value="metersSquaredPerDay"/>
+      <xs:enumeration value="feetSquaredPerDay"/>
+      <xs:enumeration value="kilogramsPerMeterSquaredPerSecond"/>
+      <xs:enumeration value="gramsPerCentimeterSquaredPerSecond"/>
+      <xs:enumeration value="gramsPerMeterSquaredPerYear"/>
+      <xs:enumeration value="gramsPerHectarePerDay"/>
+      <xs:enumeration value="kilogramsPerHectarePerYear"/>
+      <xs:enumeration value="kilogramsPerMeterSquaredPerYear"/>
+      <xs:enumeration value="molesPerKilogram"/>
+      <xs:enumeration value="molesPerGram"/>
+      <xs:enumeration value="millimolesPerGram"/>
+      <xs:enumeration value="molesPerKilogramPerSecond"/>
+      <xs:enumeration value="nanomolesPerGramPerSecond"/>
+      <xs:enumeration value="kilogramsPerSecond"/>
+      <xs:enumeration value="tonnesPerYear"/>
+      <xs:enumeration value="gramsPerYear"/>
+      <xs:enumeration value="numberPerMeterSquared"/>
+      <xs:enumeration value="numberPerKilometerSquared"/>
+      <xs:enumeration value="numberPerMeterCubed"/>
+      <xs:enumeration value="numberPerLiter"/>
+      <xs:enumeration value="numberPerMilliliter"/>
+      <xs:enumeration value="metersPerGram"/>
+      <xs:enumeration value="numberPerGram"/>
+      <xs:enumeration value="gramsPerGram"/>
+      <xs:enumeration value="microgramsPerGram"/>
+      <xs:enumeration value="cubicCentimetersPerCubicCentimeters"/>
+      <!-- removed the mass units to their named type -->
+      <!-- removed the length units to their named type -->
+      <!-- removed the angle units to their named type -->
+    </xs:restriction>
+  </xs:simpleType>
+ <!-- 
+
+angle units -->
+  <xs:simpleType name="angleUnitType">
+   <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Angle Units</doc:tooltip>
+        <doc:summary>An example of a group of units which could be added. These units are a 
+        derived typein the group of derived SI units with a special name or symbol.</doc:summary>
+        <doc:description>
+          <para>The AngleUnitType is the enumerated list of angle units. For example,
+            plane angle (radian, rad) and solid angle (steradian, sr) are actually 
+            dimensionless, and their symbols used as appropriate 
+       (e.g, sr in photometry). These unit names could be used where 
+       ever content should be restricted.</para>
+        </doc:description>
+      </xs:appinfo>
+      </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="radian"/>
+      <xs:enumeration value="degree"/>
+      <xs:enumeration value="grad"/>
+      <!--    <xs:enumeration value="steradian"/> -->
+    </xs:restriction>
+  </xs:simpleType>  
+  
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml-view.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml-view.xsd
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns="eml://ecoinformatics.org/view-2.1.1" 
+    xmlns:cov="eml://ecoinformatics.org/coverage-2.1.1" 
+    xmlns:prot="eml://ecoinformatics.org/protocol-2.1.1" 
+    xmlns:phys="eml://ecoinformatics.org/physical-2.1.1" 
+    xmlns:att="eml://ecoinformatics.org/attribute-2.1.1" 
+    xmlns:ent="eml://ecoinformatics.org/entity-2.1.1" 
+    xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+    xmlns:con="eml://ecoinformatics.org/constraint-2.1.1" 
+    xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+    targetNamespace="eml://ecoinformatics.org/view-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/entity-2.1.1" 
+  schemaLocation="eml-entity.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" 
+  schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/attribute-2.1.1" 
+  schemaLocation="eml-attribute.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/protocol-2.1.1" 
+  schemaLocation="eml-protocol.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/physical-2.1.1" 
+  schemaLocation="eml-physical.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/coverage-2.1.1" 
+  schemaLocation="eml-coverage.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" 
+  schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/constraint-2.1.1" 
+  schemaLocation="eml-constraint.xsd"/>
+  <xs:annotation>
+    <xs:documentation>
+       '$RCSfile: eml-view.xsd,v $'
+       Copyright: 1997-2002 Regents of the University of California,
+                            University of New Mexico, and
+                            Arizona State University
+        Sponsors: National Center for Ecological Analysis and Synthesis and
+                  Partnership for Interdisciplinary Studies of Coastal Oceans,
+                     University of California Santa Barbara
+                  Long-Term Ecological Research Network Office,
+                     University of New Mexico
+                  Center for Environmental Studies, Arizona State University
+   Other funding: National Science Foundation (see README for details)
+                  The David and Lucile Packard Foundation
+     For Details: http://knb.ecoinformatics.org/
+
+        '$Author: obrien $'
+          '$Date: 2008-11-14 23:50:13 $'
+      '$Revision: 1.43 $'
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml-view</doc:moduleName>
+        <doc:moduleDescription>
+        <section xmlns="">
+          <title>
+            The eml-view module - Data tables resulting from a
+            database query
+          </title>
+          <para>
+            The eml-view module describes a view from a database management system.
+            A view is a query statement that is stored as a database object and
+            executed each time the view is called.
+          </para>
+        </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all datasets that contain one or more
+        views</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="view" type="ViewType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>View</doc:tooltip>
+        <doc:summary>The View element is a container for documenting a
+        view.</doc:summary>
+        <doc:description>The View element is a container for documenting a
+        view. The structure of the view element is defined by the
+        ViewType.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="ViewType">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>ViewType</doc:tooltip>
+        <doc:summary>The ViewType complex type defines the structure for
+        documenting a view.</doc:summary>
+        <doc:description>The ViewType complex type defines the structure for
+        documenting a view. This type extends the EntityGroup with a
+        queryStatement.</doc:description>
+        
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:choice>
+      <xs:sequence>
+        <xs:group ref="ent:EntityGroup"/>
+        <xs:element name="attributeList" type="att:AttributeListType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Attribute List</doc:tooltip>
+              <doc:summary>The list of attributes associated with this
+              entity.</doc:summary>
+              <doc:description>The list of attributes associated with this
+              entity.  For more information see the eml-attribute
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="constraint" type="con:ConstraintType" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Constraint</doc:tooltip>
+              <doc:summary/>
+              <doc:description>Description of any relational constraints on '
+              this entity.  For more information see the eml-constraint
+              module.</doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="queryStatement" type="res:NonEmptyStringType">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Query Statement</doc:tooltip>
+              <doc:summary>Query syntax that produced the view</doc:summary>
+              <doc:description>The value of a queryStatement field is the
+              actual query statement stored in the database is entered here.
+              The query statement generates the entity being
+              documented.</doc:description>
+              <doc:example>Select site as SiteID,common_name as CommonName,
+              count as CountOfIndividuals from samples inner join taxonlist
+              on samples.speciesid=taxonlist.speciesid</doc:example>
+              
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:group ref="res:ReferencesGroup"/>
+    </xs:choice>
+    <xs:attribute name="id" type="res:IDType" use="optional"/>
+    <xs:attribute name="system" type="res:SystemType" use="optional"/>
+    <xs:attribute name="scope" type="res:ScopeType" use="optional" default="document"/>
+  </xs:complexType>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/eml.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/eml.xsd
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	xmlns:xml="http://www.w3.org/XML/1998/namespace"
+	xmlns="eml://ecoinformatics.org/eml-2.1.1" 
+	xmlns:res="eml://ecoinformatics.org/resource-2.1.1" 
+	xmlns:acc="eml://ecoinformatics.org/access-2.1.1" 
+	xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" 
+	xmlns:doc="eml://ecoinformatics.org/documentation-2.1.1" 
+	xmlns:prot="eml://ecoinformatics.org/protocol-2.1.1" 
+	xmlns:ds="eml://ecoinformatics.org/dataset-2.1.1" 
+	xmlns:cit="eml://ecoinformatics.org/literature-2.1.1" 
+	xmlns:sw="eml://ecoinformatics.org/software-2.1.1" 
+	targetNamespace="eml://ecoinformatics.org/eml-2.1.1">
+  <xs:import namespace="eml://ecoinformatics.org/documentation-2.1.1" schemaLocation="eml-documentation.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/dataset-2.1.1" schemaLocation="eml-dataset.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/literature-2.1.1" schemaLocation="eml-literature.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/software-2.1.1" schemaLocation="eml-software.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/protocol-2.1.1" schemaLocation="eml-protocol.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/resource-2.1.1" schemaLocation="eml-resource.xsd"/>
+  <xs:import namespace="eml://ecoinformatics.org/access-2.1.1" schemaLocation="eml-access.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+  <xs:annotation>
+    <xs:documentation> '$RCSfile: eml.xsd,v $' Copyright: 1997-2002 Regents of the University of
+      California, University of New Mexico, and Arizona State University Sponsors: National Center
+      for Ecological Analysis and Synthesis and Partnership for Interdisciplinary Studies of Coastal
+      Oceans, University of California Santa Barbara Long-Term Ecological Research Network Office,
+      University of New Mexico Center for Environmental Studies, Arizona State University Other
+      funding: National Science Foundation (see README for details) The David and Lucile Packard
+      Foundation For Details: http://knb.ecoinformatics.org/ '$Author: obrien $' '$Date: 2008/04/09
+      21:31:41 $' '$Revision: 1.59 $' This program is free software; you can redistribute it and/or
+      modify it under the terms of the GNU General Public License as published by the Free Software
+      Foundation; either version 2 of the License, or (at your option) any later version. This
+      program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+      General Public License for more details. You should have received a copy of the GNU General
+      Public License along with this program; if not, write to the Free Software Foundation, Inc.,
+      59 Temple Place, Suite 330, Boston, MA 02111-1307 USA </xs:documentation>
+    <xs:appinfo>
+      <doc:moduleDocs>
+        <doc:moduleName>eml</doc:moduleName>
+        <doc:moduleDescription>
+          <section xmlns="">
+            <title> The eml module - A metadata container </title>
+            <para> The eml module is a wrapper container that allows the inclusion of any metadata
+              content in a single EML document. The eml module is used as a container to hold
+              structured descriptions of ecological resources. In EML, the definition of a resource
+              comes from the <ulink url="http://dublincore.org/documents/usageguide/">
+                <citetitle> The Dublin Core Metadata Initiative </citetitle>
+              </ulink>, which describes a general element set used to describe "networked digital
+              resources". The top-level structure of EML has been designed to be compatible with the
+              Dublin Core syntax. In general, dataset resources, literature resources, software
+              resources, and protocol resources comprise the list of information that may be
+              described in EML. EML is largely designed to describe digital resources, however, it
+              may also be used to describe non-digital resources such as paper maps and other
+              non-digital media. <emphasis> In EML, the definition of a "Data Package" is the
+                combination of both the data and metadata for a resource. </emphasis> So, data
+              packages are built by using the &lt;eml&gt; wrapper, which will include all of
+              the metadata, and optionally the data (or references to them). All EML packages must
+              begin with the &lt;eml&gt; tag and end with the &lt;/eml&gt; tag. </para>
+            <para> The eml module may be extended to describe other resources by means of its
+              optional sub-field, &lt;additionalMetadata&gt;. This field is largely reserved
+              for the inclusion of metadata that may be highly discipline specific and not covered
+              in this version of EML, or it may be used to internally extend fields within the EML
+              standard. </para>
+          </section>
+        </doc:moduleDescription>
+        <doc:recommendedUsage>all datasets</doc:recommendedUsage>
+        <doc:standAlone>yes</doc:standAlone>
+      </doc:moduleDocs>
+      <doc:module>eml.xsd</doc:module>
+      <doc:module>eml-access.xsd</doc:module>
+      <doc:module>eml-attribute.xsd</doc:module>
+      <doc:module>eml-constraint.xsd</doc:module>
+      <doc:module>eml-coverage.xsd</doc:module>
+      <doc:module>eml-dataset.xsd</doc:module>
+      <doc:module>eml-dataTable.xsd</doc:module>
+      <doc:module>eml-entity.xsd</doc:module>
+      <doc:module>eml-literature.xsd</doc:module>
+      <doc:module>eml-methods.xsd</doc:module>
+      <doc:module>eml-party.xsd</doc:module>
+      <doc:module>eml-physical.xsd</doc:module>
+      <doc:module>eml-project.xsd</doc:module>
+      <doc:module>eml-protocol.xsd</doc:module>
+      <doc:module>eml-resource.xsd</doc:module>
+      <doc:module>eml-software.xsd</doc:module>
+      <doc:module>eml-spatialRaster.xsd</doc:module>
+      <doc:module>eml-spatialReference.xsd</doc:module>
+      <doc:module>eml-spatialVector.xsd</doc:module>
+      <doc:module>eml-storedProcedure.xsd</doc:module>
+      <doc:module>eml-text.xsd</doc:module>
+      <doc:module>eml-unitTypeDefinitions.xsd</doc:module>
+      <doc:module>eml-view.xsd</doc:module>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:element name="eml">
+    <xs:annotation>
+      <xs:appinfo>
+        <doc:tooltip>Ecological Metadata</doc:tooltip>
+        <doc:summary>A collection of EML metadata and additional metadata linked using the inline
+          references.</doc:summary>
+        <doc:description>The "eml" element allows for the inclusion of any metadata content in a
+          single EML document. In general, dataset resources, literature resources, and software
+          resources, or another type that extends eml-resource are described using an eml document.
+          The eml document represents a "package" that can contain both metadata and data. It can
+          optionally include non-EML metadata through the flexibility of the "additionalMetadata"
+          element. Any additional metadata that is provided can provide a pointer into the EML
+          metadata indicating what the context of the additional metadata is (i.e., what it
+          describes). For example, a spatial raster image might be described in EML, and an FGDC
+          CSDGM metadata document could be included in the additionalMetadata element with a pointer
+          to the EML spatialRaster element to indicate that the FGDC metadata is providing
+          supplemental documentation about that particular image entity. There is no validity
+          constraint that restricts what metadata may be present in additionalMetadata. </doc:description>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="access" type="acc:AccessType" minOccurs="0">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Access</doc:tooltip>
+              <doc:summary>Access control rules for the entire resource, which can be overridden by access rules in distribution trees</doc:summary>
+              <doc:description>An optional access tree at this location controls access to the entire metadata document. If this access element is omitted from the document, then the package submitter should be given full access to the package but all other users should be denied all access. </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:choice>
+          <xs:element name="dataset" type="ds:DatasetType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Dataset Resource</doc:tooltip>
+                <doc:summary>A resource that describes a data set, which can include one or more
+                  data entities such as data tables. </doc:summary>
+                <doc:description>A resource that describes a data set, which can include one or more
+                  data entities such as data tables and spatial images (raster and vector). If
+                  included, this represents the primary resource that is described in this eml
+                  document. </doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="citation" type="cit:CitationType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Literature Resource</doc:tooltip>
+                <doc:summary>A resource that describes a literature citation that one might find in
+                  a bibliography. </doc:summary>
+                <doc:description>A resource that describes a literature citation that one might find
+                  in a bibliography. If included, this represents the primary resource that is
+                  described in this eml document. </doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="software" type="sw:SoftwareType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Software Resource</doc:tooltip>
+                <doc:summary>A resource that describes a software package, which can include
+                  commercial and non-commercial software as well as data processing programs. </doc:summary>
+                <doc:description>A resource that describes a software package, which can include
+                  commercial and non-commercial software as well as data processing programs. If
+                  included, this represents the primary resource that is described in this eml
+                  document. </doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="protocol" type="prot:ProtocolType">
+            <xs:annotation>
+              <xs:appinfo>
+                <doc:tooltip>Protocol Resource</doc:tooltip>
+                <doc:summary>A resource that describes a scientific protocol, which can include one
+                  or more descriptions of methods and procedures. </doc:summary>
+                <doc:description>A resource that describes a scientific protocol, which can include
+                  one or more descriptions of methods and procedures. If included, this represents
+                  the primary resource that is described in this eml document. </doc:description>
+              </xs:appinfo>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+        <xs:element name="additionalMetadata" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:appinfo>
+              <doc:tooltip>Additional Metadata</doc:tooltip>
+              <doc:summary>A flexible field for including any other relevant metadata that pertains
+                to the resource being described.</doc:summary>
+              <doc:description>A flexible field for including any other relevant metadata that
+                pertains to the resource being described. This field allows EML to be extensible in
+                that any XML-based metadata can be included in this element, including metadata from
+                other standards such as the FGDC CSDGM. The "describes" element of this field allows
+                the specific part of the resource which is described by the additional metadata to
+                be indicated formally. </doc:description>
+            </xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="describes" type="res:NonEmptyStringType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Describes Reference</doc:tooltip>
+                    <doc:summary>A pointer to the id attribute for the sub-portion of the resource
+                      that is described by this additional metadata. </doc:summary>
+                    <doc:description>A pointer to the id attribute for the sub-portion of the
+                      resource that is described by this additional metadata. This is a formal field
+                      in that it is an error to provide a value in the "describes" element that does
+                      not correspond to the value of one of the "id" attributes in another eml
+                      module. This is designed to allow automated processors to discover the
+                      contextual relationship between the additional metadata and the resource it
+                      describes. </doc:description>
+                    <doc:example>knb.343.22</doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="metadata">
+                <xs:annotation>
+                  <xs:appinfo>
+                    <doc:tooltip>Additional metadata</doc:tooltip>
+                    <doc:summary>This element contains the additional metadata that is to be
+                      included in the document. The content of this field can be any well-formed XML
+                      fragment. </doc:summary>
+                    <doc:description>This element contains the additional metadata to be included in
+                      the document. This element should be used for extending EML to include
+                      metadata that is not already available in another part of the EML
+                      specification, or to include site- or system-specific extensions that are
+                      needed beyond the core metadata. The additional metadata contained in this
+                      field describes the element referenced in the 'describes' element preceding
+                      it. The content of this field is any well-formed XML fragment. If that content
+                      contains namespace declarations, and if the namespace declaration can be
+                      resolved to a schema definition, then the content will be validated against
+                      that schema definition. If no namespace is present, or if no schema can be
+                      resolved, validation for this fragment will be skipped (validation is "lax"). </doc:description>
+                    <doc:example><![CDATA[
+                      <embargoDate>2006-10-10</embargoDate>
+                      ]]></doc:example>
+                  </xs:appinfo>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:any processContents="lax">
+                      <xs:annotation>
+                        <xs:appinfo>
+                          <doc:tooltip>Any Metadata</doc:tooltip>
+                          <doc:summary>Any well-formed XML-formatted metadata may be inserted at
+                            this location in the EML document. If an element inserted here contains
+                            a reference to its namespace, and if there is an association between
+                            that namespace and an XML Schema that can be located by the processing
+                            application, then the processing application must validate the metadata
+                            element. If these conditions are not met, then validation need not
+                            occur. </doc:summary>
+                          <doc:description>Any well-formed XML-formatted metadata may be inserted at
+                            this location in the EML document. If an element inserted here contains
+                            a reference to its namespace, and if there is an association between
+                            that namespace and an XML Schema that can be located by the processing
+                            application, then the processing application must validate the metadata
+                            element. If these conditions are not met, then validation need not
+                            occur. </doc:description>
+                        </xs:appinfo>
+                      </xs:annotation>
+                    </xs:any>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="id" type="res:IDType" use="optional"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="packageId" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Package Identifer</doc:tooltip>
+            <doc:summary>A unique identifier for this entire EML metadata document that can be used
+              to reference it elsewhere. </doc:summary>
+            <doc:description>A unique identifier for this entire EML metadata document that can be
+              used to reference it elsewhere. This identifier can be interpreted as the formal
+              accession number for this EML package, and is therefore required. It must be unique
+              within a particular data management system (see the "system" attribute). </doc:description>
+            <doc:example>knb.343.22</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="system" type="res:SystemType" use="required"/>
+      <xs:attribute name="scope" type="res:ScopeType" fixed="system">
+        <xs:annotation>
+          <xs:appinfo>
+            <doc:tooltip>Identifer Scope</doc:tooltip>
+            <doc:summary>The scope of the identifier.</doc:summary>
+            <doc:description>The scope of the identifier. Scope is generally set to either "system",
+              meaning that it is scoped according to the "system" attribute, or "document" if it is
+              only to be in scope within this single document instance. In this particular use of
+              scope, it is FIXED to be "system" because the packageId is required and always has the
+              scope of the required "system". </doc:description>
+            <doc:example>system</doc:example>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang" use="optional" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/shinyApp/_infoBuilder/altFiles/eml/stmml.xsd
+++ b/shinyApp/_infoBuilder/altFiles/eml/stmml.xsd
@@ -1,0 +1,3302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  xmlns="http://www.xml-cml.org/schema/stmml-1.1"   
+  xmlns:sch="http://www.ascc.net/xml/schematron"  
+  targetNamespace="http://www.xml-cml.org/schema/stmml-1.1" 
+  elementFormDefault="qualified">
+  <xsd:annotation>
+    <xsd:documentation xml:lang="en">
+      <div class="curation">
+        <ul>
+          <li>created by hand
+      2001-11-20</li>
+          <li>First draft 2001-11-20</li>
+        </ul>
+        <p>STMML supports domain-independent STM information components</p>
+      </div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:annotation>
+    <xsd:appinfo>
+      <sch:title>Schematron validation</sch:title>
+      <sch:ns uri="http://www.xml-cml.org/schema/stmml-1.1"/>
+    </xsd:appinfo>
+  </xsd:annotation>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="heading">Data Types and Data Structure</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="subheading">Overview</div>
+      <div class="description">
+        <p>STM-ML defines a number of data types suited to STM. It also defines
+    a number of complex data strucures such as arrays, matrices and tables.
+    the constraints are sometimes created through elements and sometimes
+    through attributes. We classify the general components as follows:</p>
+        <p>
+          <b>Abstract Data Structures</b>
+        </p>
+        <ul>
+          <li>
+            <a href="el.scalar">scalar</a>. A scalar quantity, expressible as a string, but
+    with many optional facets such as errors, units, ranges, etc. Most elements
+    may have <a href="st.countType">countType</a> attribute to indicate more than
+    one instance.</li>
+          <li>
+            <a href="el.array">array</a>. An array of homogeneous <tt>scalar</tt>s
+    whose size is described by <a href="st.sizeType">sizeType</a>. <a href="st.delimiterType">
+    Delimiter</a>s in string representations can ve varied.</li>
+          <li>
+            <a href="el.matrix">matrix</a>. A rectangular (often square) matrix of
+    homogeneous <tt>scalar</tt>s. Many matrices have special functions
+    (see <a href="el.matrixType">matrixType</a>) such as geometric
+    transformations</li>
+          <li>
+            <a href="el.table">table</a>. An table where the columns are homogeneous
+    <tt>array</tt>s. </li>
+          <li>
+            <a href="el.list">list</a>. A list of heterogeneous components from any
+    namespace.</li>
+          <li>
+            <a href="st.sizeType">sizeType</a>. Size of arrays</li>
+          <li>
+            <a href="st.delimiterType">delimiterType</a>. A lexical delimiter</li>
+        </ul>
+        <p>
+          <b>Links and References</b>
+        </p>
+        <ul>
+          <li>
+            <a href="el.link">link</a>. Support for simple hyperlinks and link structures</li>
+          <li>
+            <a href="st.refType">refType</a>. A reference to an element</li>
+          <li>
+            <a href="st.namespaceRefType">namespaceRefType</a>. A reference to an element, including
+    namespace-like prefixes</li>
+        </ul>
+        <p>
+          <b>Data-based simpleTypes</b>
+        </p>
+        <ul>
+          <li>
+            <a href="st.coordinate2Type">coordinate2Type</a>. A 2-D coordinate</li>
+          <li>
+            <a href="st.coordinate3Type">coordinate3Type</a>. A 3-D coordinate</li>
+          <li>
+            <a href="st.dataTypeType">dataTypeType</a>. An enumeration of
+    data types (similar to those in XML Schema).</li>
+          <li>
+            <a href="st.errorBasisType">errorBasisType</a>. Basis of numeric error estimates</li>
+          <li>
+            <a href="st.minType">minType</a>. Minimum value</li>
+          <li>
+            <a href="st.maxType">maxType</a>. Maximum value</li>
+        </ul>
+        <p>
+          <b>Common attribute types</b>
+        </p>
+        <ul>
+          <li>
+            <a href="st.idType">idType</a>. Specifies lexical patterns for IDs</li>
+          <li>
+            <a href="attGp.idGroup">idGroup</a>. ID attribute (highly encouraged)</li>
+          <li>
+            <a href="attGp.titleGroup">titleGroup</a>. Title attribute (highly encouraged)</li>
+          <li>
+            <a href="attGp.convGroup">convGroup</a>. Convention attribute</li>
+        </ul>
+      </div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="subheading">Data structure</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="array" id="el.array">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+            A homogenous 1-dimensional array of similar objects.</div>
+        <div class="description">
+          <p>
+            <tt>array</tt> manages a homogenous 1-dimensional array of similar objects. These
+            can be encoded as strings (i.e. XSD-like datatypes) and are concatenated as
+            string content. The size of the array should always be &gt;= 1.
+         </p>
+          <p>The default delimiter is whitespace. The <tt>normalize-space()</tt> function of
+         XSLT could be used to normalize all whitespace to single spaces and this would not affect
+         the value of the array elements. To extract the elements <tt>java.lang.StringTokenizer</tt>
+         could be used. If the elements themselves contain whitespace then a different delimiter
+         must be used and is identified through the <tt>delimiter</tt> attribute. This method is
+         mandatory if it is required to represent empty strings. If a delimiter is used it MUST
+         start and end the array - leading and trailing whitespace is ignored. Thus <tt>size+1</tt>
+         occurrences of the delimiter character are required. If non-normalized whitespace is to be
+         encoded (e.g. newlines, tabs, etc) you are recommended to translate it character-wise
+         to XML character entities.
+         </p>
+          <p>Note that normal Schema validation tools cannot validate the elements
+         of <b>array</b> (they are defined as <tt>string</tt>) However if the string is
+         split, a temporary schema
+         can be constructed from the type and used for validation. Also the type
+         can be contained in a dictionary and software could decide to retrieve this
+         and use it for validation.</p>
+          <p>When the elements of the <tt>array</tt> are not simple scalars
+         (e.g. <a href="el.scalar">scalar</a>s with a value and an error, the
+         <tt>scalar</tt>s should be used as the elements. Although this is
+         verbose, it is simple to understand. If there is a demand for
+         more compact representations, it will be possible to define the
+         syntax in a later version.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;array size="5" title="value"
+  dataType="xsd:decimal"&gt;  1.23 2.34 3.45 4.56 5.67&lt;/array&gt;
+
+</pre>
+          <p>the <tt>size</tt> attribute is not mandatory but provides a useful validity
+         check): </p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;array size="5" title="initials" dataType="xsd:string"
+  delimiter="/"&gt;/A B//C/D-E/F/&lt;/array&gt;
+
+</pre>
+          <p>Note that the second array-element is the empty string ''.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;array title="mass" size="4"
+  units="unit:g"
+  errorBasis="observedStandardDeviation"
+  minValues="10 11 10 9"
+  maxValues="12 14 12 11"
+  errorValues="1 2 1 1"
+  dataType="xsd:float"&gt;11 12.5 10.9 10.2
+&lt;/array&gt;
+
+</pre>
+        </div>
+      </xsd:documentation>
+      <xsd:appinfo>
+        <sch:pattern xmlns="http://www.ascc.net/xml/schematron" name="array">
+         </sch:pattern>
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+          <xsd:attribute name="dataType" type="dataTypeType" default="xsd:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">all elements of the array must have the same dataType</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="errorValues" type="floatArrayType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">an optional array of error values for numeric arrays</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="errorBasis" type="errorBasisType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">A string describing the basis of the errors</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="minValues" type="floatArrayType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">an optional array of minimum values for numeric arrays</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="maxValues" type="floatArrayType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">an optional array of maximum values for numeric arrays</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="units" type="unitsType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">a string denoting the units (recommended for numeric quantities!!).
+                   All elements must have the same units</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="delimiter" type="delimiterType"/>
+          <xsd:attribute name="size" type="xsd:positiveInteger"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="scalar" id="el.scalar">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An element to hold scalar data.</div>
+        <div class="description">
+          <p>
+            <tt>scalar</tt> holds scalar data under a single
+            generic container. The semantics are usually resolved by
+            linking to a dictionary.
+             <b>scalar</b> defaults to a scalar string but
+             has attributes which affect the type.
+         </p>
+          <p>
+            <tt>scalar</tt> does not necessarily reflect a physical object (for which
+         <a href="el.object">object</a> should be used). It may reflect a property of an object
+         such as temperature, size, etc. </p>
+          <p>Note that normal Schema validation tools cannot validate the data type
+         of <b>scalar</b> (it is defined as <tt>string</tt>), but that a temporary schema
+         can be constructed from the type and used for validation. Also the type
+         can be contained in a dictionary and software could decide to retrieve this
+         and use it for validation.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;scalar
+    dataType="xsd:decimal"
+    errorValue="1.0"
+    errorBasis="observedStandardDeviation"
+    title="body weight"
+    dictRef="zoo:bodywt"
+    units="units:g"&gt;34.3&lt;/scalar&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+          <xsd:attribute name="dataType" type="dataTypeType" default="xsd:string"/>
+          <xsd:attribute name="errorValue" type="xsd:decimal"/>
+          <xsd:attribute name="errorBasis" type="errorBasisType"/>
+          <xsd:attribute name="minValue" type="minType"/>
+          <xsd:attribute name="maxValue" type="maxType"/>
+          <xsd:attribute name="units" type="unitsType"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="matrix" id="el.matrix">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A rectangular matrix of any quantities</div>
+        <div class="description">
+          <p>By default <tt>matrix</tt> represents
+        a rectangular matrix of any quantities
+            representable as XSD or STMML dataTypes. It consists of
+            <tt>rows*columns</tt> elements, where <tt>columns</tt> is the
+     fasting moving index. Assuming the elements are counted from 1 they are
+     ordered <tt>V[1,1],V[1,2],...V[1,columns],V[2,1],V[2,2],...V[2,columns],
+     ...V[rows,1],V[rows,2],...V[rows,columns]</tt>
+          </p>
+          <p>By default whitespace is used to separate matrix elements; see
+     <a href="el.array">array</a> for details. There are NO characters or markup
+     delimiting the end of rows; authors must be careful!. The <tt>columns</tt>
+     and <tt>rows</tt> attributes have no default values; a row vector requires
+     a <tt>rows</tt> attribute of 1.</p>
+          <p>
+            <tt>matrix</tt> also supports many types of square matrix, but at present we
+     require all elements to be given, even if the matrix is symmetric, antisymmetric
+     or banded diagonal. The <tt>matrixType</tt> attribute allows software to
+     validate and process the type of matrix.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;matrix id="m1" title="mattrix-1" dictRef="foo:bar"
+  rows="3" columns="3" dataType="xsd:decimal"
+  delimiter="|" matrixType="squareSymmetric" units="unit:m"
+  &gt;|1.1|1.2|1.3|1.2|2.2|2.3|1.3|2.3|3.3!&lt;/matrix&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="dataType" type="dataTypeType" default="xsd:float"/>
+          <xsd:attribute name="delimiter" type="delimiterType"/>
+          <xsd:attribute name="rows" type="sizeType" use="required">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">
+                  <p>Number of rows</p>
+                </div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="columns" type="sizeType" use="required">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">
+                  <p>Number of columns</p>
+                </div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="units" type="unitsType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">
+                  <p>units (recommended for numeric quantities!!)</p>
+                </div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+          <xsd:attribute name="matrixType" type="matrixType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">
+                  <p>Type of matrix (mainly square ones)</p>
+                </div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="errorValues" type="floatArrayType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">an optional array of error values for numeric matrices</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="errorBasis" type="errorBasisType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">A string describing the basis of the errors</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="minValues" type="floatArrayType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">an optional array of minimum values for numeric matrices</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="maxValues" type="floatArrayType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">an optional array of maximum values for numeric matrices</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="table" id="el.table">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A rectangular table of any quantities</div>
+        <div class="description">
+          <p>By default <tt>table</tt> represents a rectangular table of any quantities
+               representable as XSD or STMML dataTypes. The default layout is columnwise,
+               with <tt>columns</tt> columns,
+               where each column is a (homogeneous) <a href="el.array">array</a> of
+               size <tt>rows</tt> data. This is the "normal" orientation of data tables
+               but the table display could be transposed by XSLT transformation if required.
+         Access is to columns, and thence to the data within them. DataTyping, delimiters,
+         etc are delegated to the arrays, which must all be of the same size. For
+         verification it is recommended that every array carries a <tt>size</tt>
+         attribute.
+               </p>
+        </div>
+        <div class="example">
+          <pre>&lt;table rows="3" columns="2" title="people"&gt;
+  &lt;array title="age" dataType="xsd:integer"&gt;3 5 7&lt;/array&gt;
+  &lt;array title="name" dataType="xsd:string"&gt;Sue Fred Sandy&lt;/array&gt;
+&lt;/table&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="array" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="rows" type="sizeType" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="description">
+              <p>Number of rows</p>
+            </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="columns" type="sizeType" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="description">
+              <p>Number of columns</p>
+            </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="list" id="el.list">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A generic container with no implied semantics</div>
+        <div class="description">
+          <p>
+       A generic container with no implied semantics. It just contains
+      things and can have attributes which bind conventions to it. It could often
+      act as the root element in an STM document.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;list&gt;
+  &lt;array title="animals"&gt;frog bear toad&lt;/array&gt;
+  &lt;scalar title="weight" dataType="xsd:float"&gt;3.456&lt;/scalar&gt;
+&lt;/list&gt;
+
+      </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attribute name="type" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="subheading">Data-based simpleTypes</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType name="coordinate2Type" id="st.coordinate2Type">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An x/y coordinate pair</div>
+        <div class="description">
+          <p>An x/y coordinate pair consisting of
+         two real numbers, separated by whitespace or a comma.
+         In arrays and matrices, it may be useful to set a separate delimiter</p>
+        </div>
+        <div class="example">
+          <pre>
+
+&lt;list&gt;
+  &lt;array
+      &gt;1.2,3.4   3.2,4.5   6.7,23.1 &lt;/array&gt;
+  &lt;array delimiter="/"
+      &gt;/1.2 3.4/3.2 4.5/6.7 23.1/&lt;/array&gt;
+&lt;/list&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\s*([\-]|[+])?\d*\.?\d*(\s+|[,])([\-]|[+])?\d*\.?\d*\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="coordinate3Type" id="st.coordinate3Type">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An x/y/z coordinate triple</div>
+        <div class="description">
+          <p>An x/y/z coordinate triple consisting of
+            three real numbers, separated by whitespace or commas.
+            In arrays and matrices, it may be useful to set a separate delimiter</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;list&gt;
+  &lt;array&gt;1.2,3.4,1.2
+    3.2,4.5,7.3   6.7,23.1,5.6 &lt;/array&gt;
+  &lt;array delimiter="/"
+  &gt;/1.2 3.4 3.3/3.2 4.5 4.5/6.7 23.1 5.6/&lt;/array&gt;
+&lt;/list&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\s*([\-]|[+])?\d*\.?\d*(\s+|[,])([\-]|[+])?\d*\.?\d*(\s+|[,])([\-]|[+])?\d*\.?\d*\s*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="dataTypeType" id="st.dataTypeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>an enumerated type for all builtin allowed dataTypes in STM</p>
+        </div>
+        <div class="description">
+          <p>
+            <tt>dataTypeType</tt> represents an enumeration of allowed dataTypes
+               (at present identical with those in XML-Schemas (Part2- datatypes).
+               This means that implementers should be able to use standard XMLSchema-based
+               tools for validation without major implementation problems.
+            </p>
+          <p>It will often be used an an attribute on
+            <a href="el.scalar">scalar</a>,
+            <a href="el.array">array</a> or
+            <a href="el.matrix">matrix</a>
+            elements.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;list xmlns="http://www.xml-cml.org/schema/core"&gt;
+  &lt;scalar dataType="xsd:boolean" title="she loves me"&gt;true&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:float" title="x"&gt;23.2&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:duration" title="egg timer"&gt;PM4&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:dateTime" title="current data and time"&gt;2001-02-01:00:30&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:time" title="wake up"&gt;06:00&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:date" title="where is it"&gt;1752-09-10&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:anyURI" title="CML site"&gt;http://www.xml-cml.org/&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:QName" title="CML atom"&gt;cml:atom&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:normalizedString" title="song"&gt;the mouse ran up the clock&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:language" title="UK English"&gt;en-GB&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:Name" title="atom"&gt;atom&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:ID" title="XML ID"&gt;_123&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:integer" title="the answer"&gt;42&lt;/scalar&gt;
+  &lt;scalar dataType="xsd:nonPositiveInteger" title="zero"&gt;0&lt;/scalar&gt;
+&lt;/list&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="xsd:string"/>
+      <xsd:enumeration value="xsd:boolean"/>
+      <xsd:enumeration value="xsd:float"/>
+      <xsd:enumeration value="xsd:double"/>
+      <xsd:enumeration value="xsd:decimal"/>
+      <xsd:enumeration value="xsd:duration"/>
+      <xsd:enumeration value="xsd:dateTime"/>
+      <xsd:enumeration value="xsd:time"/>
+      <xsd:enumeration value="xsd:date"/>
+      <xsd:enumeration value="xsd:gYearMonth"/>
+      <xsd:enumeration value="xsd:gYear"/>
+      <xsd:enumeration value="xsd:gMonthDay"/>
+      <xsd:enumeration value="xsd:gDay"/>
+      <xsd:enumeration value="xsd:gMonth"/>
+      <xsd:enumeration value="xsd:hexBinary"/>
+      <xsd:enumeration value="xsd:base64Binary"/>
+      <xsd:enumeration value="xsd:anyURI"/>
+      <xsd:enumeration value="xsd:QName"/>
+      <xsd:enumeration value="xsd:NOTATION"/>
+      <xsd:enumeration value="xsd:normalizedString"/>
+      <xsd:enumeration value="xsd:token"/>
+      <xsd:enumeration value="xsd:language"/>
+      <xsd:enumeration value="xsd:IDREFS"/>
+      <xsd:enumeration value="xsd:ENTITIES"/>
+      <xsd:enumeration value="xsd:NMTOKEN"/>
+      <xsd:enumeration value="xsd:NMTOKENS"/>
+      <xsd:enumeration value="xsd:Name"/>
+      <xsd:enumeration value="xsd:NCName"/>
+      <xsd:enumeration value="xsd:ID"/>
+      <xsd:enumeration value="xsd:IDREF"/>
+      <xsd:enumeration value="xsd:ENTITY"/>
+      <xsd:enumeration value="xsd:integer"/>
+      <xsd:enumeration value="xsd:nonPositiveInteger"/>
+      <xsd:enumeration value="xsd:negativeInteger"/>
+      <xsd:enumeration value="xsd:long"/>
+      <xsd:enumeration value="xsd:int"/>
+      <xsd:enumeration value="xsd:short"/>
+      <xsd:enumeration value="xsd:byte"/>
+      <xsd:enumeration value="xsd:nonNegativeInteger"/>
+      <xsd:enumeration value="xsd:unsignedLong"/>
+      <xsd:enumeration value="xsd:unsignedInt"/>
+      <xsd:enumeration value="xsd:unsignedShort"/>
+      <xsd:enumeration value="xsd:unsignedByte"/>
+      <xsd:enumeration value="xsd:positiveInteger"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="summary">Array-based simpleTypes</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType name="sizeType" id="st.sizeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">The size of an array</div>
+        <div class="description">
+          <p>The size of an array. Redundant, but serves as a check
+         for processing software (useful if delimiters are used)</p>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:positiveInteger"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="delimiterType" id="st.delimiterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A non-whitespace character used in arrays to separate components</div>
+        <div class="description">
+          <p>Some STM-ML elements (such as <a href="el.array">array</a>) have
+        content representing concatenated values. The default separator is
+        whitespace (which can be normalised) and this should be used whenever
+        possible. However in some cases the values are empty, or contain whitespace or other
+        problematic punctuation, and a delimiter is required.</p>
+          <p>Note that the content string MUST start and end with the delimiter so
+        there is no ambiguity as to what the components are. Only printable
+        characters from the ASCII character set should be used, and character
+        entities should be avoided.</p>
+          <p>When delimiters are used to separate precise whitespace this should always
+        consist of spaces and not the other allowed whitespace characters
+        (newline, tabs, etc.). If the latter are important it is probably best to redesign
+        the application.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;array size="4" delimiter="|"&gt;|A|B12||D and   E|&lt;/array&gt;
+
+
+ <em>The values in the array are</em>
+  "A", "B12", "" (empty string) and "D and   E"
+ <em>note the spaces</em>
+          </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="floatArrayType" id="st.floatArrayType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An array of floats</div>
+        <div class="description">
+          <p>An array of floats or other real numbers.
+            Not used in STM Schema, but re-used by CML.
+            </p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;atomArray xmlns="http://www.xml-cml.org/schema/core"
+  x2="1.2 2.3 3.4 5.6"/&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:list itemType="xsd:decimal"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="matrixType" id="st.matrixType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">Allowed <a href="el.matrix">matrix</a> types</div>
+        <div class="description">
+          <p>Allowed <tt>matrix</tt> types.
+       These are mainly square matrices</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;matrix id="m1" title="mattrix-1" dictRef="foo:bar"
+  rows="3" columns="3" dataType="xsd:decimal"
+  delimiter="|" matrixType="squareSymmetric" units="unit:m"
+  &gt;|1.1|1.2|1.3|1.2|2.2|2.3|1.3|2.3|3.3!&lt;/matrix&gt;
+
+      </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="rectangular"/>
+          <xsd:enumeration value="square"/>
+          <xsd:enumeration value="squareSymmetric"/>
+          <xsd:enumeration value="squareAntisymmetric"/>
+          <xsd:enumeration value="diagonal">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="description">Symmetric. Elements are zero except on the diagonal</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="upperTriangular">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="description">Square. Elements are zero below the diagonal
+            <pre>
+1 2 3 4
+0 3 5 6
+0 0 4 8
+0 0 0 2
+      </pre>
+                </div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="lowerTriangular">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="description">Symmetric. Elements are zero except on the diagonal</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="unitary"/>
+          <xsd:enumeration value="rowEigenvectors"/>
+          <xsd:enumeration value="rotation22"/>
+          <xsd:enumeration value="rotationTranslation32"/>
+          <xsd:enumeration value="homogeneous33"/>
+          <xsd:enumeration value="rotation33"/>
+          <xsd:enumeration value="rotationTranslation43"/>
+          <xsd:enumeration value="homogeneous44"/>
+          <xsd:enumeration value="square"/>
+          <xsd:enumeration value="square"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="namespaceRefType"/>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+  <xsd:simpleType name="countType" id="st.countType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>A count multiplier for certain elements</p>
+        </div>
+        <div class="description">
+          <p>A count multiplier for certain elements, such as
+            <tt>action</tt> or <tt>object</tt>.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;list&gt;
+&lt;object title="frog" count="10"/&gt;
+&lt;action title="step3" count="3"&gt;
+  &lt;p&gt;Add 10 ml reagent&lt;/p&gt;
+&lt;/action&gt;
+&lt;/list&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:integer">
+      <xsd:minInclusive value="1"/>
+      <xsd:maxInclusive value="999999999999"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="summary">General simpleTypes</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType name="idType" id="st.idType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A unique ID for STM elements</div>
+        <div class="description">
+          <p>A unique ID for STM elements. This is not formally
+          of type ID (an XML NAME which must start with a letter and contain only letters,
+          digits and <tt>.-_:</tt>). It is recommended that IDs start with a letter,
+          and contain no punctuation or whitespace. The function <tt>generate-id()</tt>
+          in XSLT will generate semantically void unique IDs</p>.
+          <p>It is difficult to ensure uniqueness when documents are merged. We suggest
+          namespacing IDs, perhaps using the containing elements as the base.
+          Thus <tt>mol3:a1</tt> could be a useful unique ID.
+          However this is still experimental.</p>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[A-Za-z0-9_\-]+(:[A-Za-z0-9_\-]+)?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:attributeGroup name="idGroup" id="attGp.id">
+    <xsd:attribute name="id" type="idType" id="att.id">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">A attribute prividing a unique ID for STM elements</div>
+          <div class="description">
+            <p>See <a href="st.idType">idType</a> for full documentation.</p>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="titleGroup" id="attGp.title">
+    <xsd:attribute name="title" type="xsd:string" id="att.title">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">An (optional) title on most STM elements. Uncontrolled</div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="convGroup" id="attGp.conv">
+    <xsd:attribute name="convention" type="namespaceRefType" default="CML" id="att.convention">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">A reference to a convention</div>
+          <div class="description">
+            <p>A reference to a convention which is inherited by all the subelements.</p>
+            <p>It may be useful to create conventions with namespaces,
+         </p>
+            <p>this attribute is inherited by its child elements; thus a <tt>molecule</tt>
+    with a convention sets the default for its bonds and atoms. This can be overwritten
+    if necessary by an explicit <tt>convention</tt>.</p>
+            <p>Use of convention will normally require non-STM-ML semantics, and should be used with
+    caution. We would expect that conventions prefixed with "ISO" would be useful,
+    such as ISO8601 for dateTimes.</p>
+          </div>
+          <div class="example">
+            <pre>
+&lt;bond convention="fooChem" order="-5"
+   xmlns:fooChem="http://www.fooChem/conventions"/&gt;
+
+     </pre>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="summary">Numeric types</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType name="errorBasisType" id="st.errorBasisType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">The basis of an error value</div>
+        <div class="description">
+          <p>Errors in values can be of several types and this simpleType
+         provides a small controlled vocabulary</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;scalar
+    dataType="xsd:decimal"
+    errorValue="1.0"
+    errorBasis="observedStandardDeviation"
+    title="body weight"
+    dictRef="zoo:bodywt"
+    units="units:g"&gt;34.3&lt;/scalar&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="observedRange"/>
+      <xsd:enumeration value="observedStandardDeviation"/>
+      <xsd:enumeration value="observedStandardError"/>
+      <xsd:enumeration value="estimatedStandardDeviation"/>
+      <xsd:enumeration value="estimatedStandardError"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="maxType" id="st.maxType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">The maximum INCLUSIVE value of a quantity</div>
+        <div class="description">
+          <p>The maximum INCLUSIVE value of a sortable quantity such as
+          numeric, date or string. It should be ignored for dataTypes such as URL.
+          The use of <tt>min</tt> and
+        <tt>max</tt> attributes can be used to give a range for the quantity.
+       The statistical basis of this range is not defined. The value of <tt>max</tt>
+       is usually an observed
+       quantity (or calculated from observations). To restrict a value, the <tt>
+       maxExclusive</tt> type in a dictionary should be used.</p>
+          <p>The type of the maximum is the same as the quantity to which it refers - numeric,
+       date and string are currently allowed</p>
+        </div>
+        <div class="example">
+          <pre>&lt;scalar dataType="xsd:float" maxValue="20" minValue="12"&gt;15&lt;/scalar&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:simpleType name="minType" id="st.minType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">The minimum INCLUSIVE value of a quantity</div>
+        <div class="description">
+          <p>The minimum INCLUSIVE value of a sortable quantity such as
+            numeric, date or string. It should be ignored for dataTypes such as URL.
+            The use of <tt>min</tt> and
+          <tt>min</tt> attributes can be used to give a range for the quantity.
+         The statistical basis of this range is not defined. The value of <tt>min</tt>
+         is usually an observed
+         quantity (or calculated from observations). To restrict a value, the <tt>
+         minExclusive</tt> type in a dictionary should be used.</p>
+          <p>The type of the minimum is the same as the quantity to which it refers - numeric,
+         date and string are currently allowed</p>
+        </div>
+        <div class="example">
+          <pre>&lt;scalar dataType="xsd:float" maxValue="20" minValue="12"&gt;15&lt;/scalar&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="subheading">Links and References</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="link" id="el.link">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An internal or external link to STMML or other object(s)</div>
+        <div class="description">
+          <p>
+            <tt>link</tt> is an internal or external link to STMML or other object(s). </p>
+          <p>
+            <b>Semantics are similar to XLink, but simpler and only a subset is implemented.</b>
+         This is intended to make the instances easy to create and read, and software
+         relatively easy to implement. The architecture is:</p>
+          <ul>
+            <li>
+              <b>A single element (<tt>link</tt>) used for all linking purposes</b>. </li>
+            <li>
+              <b>The link types are determined by the <tt>type</tt> attribute and can be:</b>.
+        <ul>
+                <li>
+                  <b>locator</b>. This points to a single target and must carry either a <tt>ref</tt> or <tt>href</tt> attribute.
+        <tt>locator</tt> links are usually children of an extended link.
+        <li>
+                    <b>arc</b>. This is a 1:1 link with both ends (<tt>from</tt> and <tt>to</tt>) defined.</li>
+                  <li>
+                    <b>extended</b>. This is usually a parent of several locator links and serves
+        to create a grouping of link ends (i.e. a list of references in documents).</li>
+        Many-many links can be built up from arcs linking extended elements</li>
+              </ul>
+              <p>All links can have optional <tt>role</tt> attributes. The semantics of this are not defined;
+        you are encouraged to use a URI as described in the XLink specification.</p>
+              <p>There are two address spaces: </p>
+              <ul>
+                <li>The <tt>href</tt> attribute on locators behaves in the same way as <tt>href</tt> in
+        HTML and is of type <tt>xsd:anyURI</tt>. Its primary use is to use XPointer to reference
+        elements outside the document.</li>
+                <li>The <tt>ref</tt> attribute on locators and the <tt>from</tt> and <tt>to</tt>
+        attributes on <tt>arc</tt>s refer to IDs (<em>without</em> the '#' syntax).</li>
+              </ul>
+              <p>Note: several other specific linking mechanisms are defined elsewhere in STM. <a href="         el.relatedEntry">relatedEntry</a> should be used in dictionaries, and <a href="st.dictRef">dictRef</a>
+        should be used to link to dictionaries. There are no required uses of <tt>link</tt> in STM-ML
+        but we have used it to map atoms, electrons and bonds in reactions in CML</p>
+            </li>
+          </ul>
+          <p>
+            <b>Relation to XLink</b>.
+         At present (2002) we are not aware of generic XLink
+         processors from which we would benefit, so the complete implementation brings little
+         extra value.
+         Among the simplifications from Xlink are:</p>
+          <ul>
+            <li>
+              <tt>type</tt> supports only <tt>extended</tt>, <tt>locator</tt> and <tt>arc</tt>
+            </li>
+            <li>
+              <tt>label</tt> is not supported and <tt>id</tt>s are used as targets of links.</li>
+            <li>
+              <tt>show</tt> and <tt>actuate</tt> are not supported.</li>
+            <li>
+              <tt>xlink:title</tt> is not supported (all STM elements can have a <tt>title</tt>
+         attribute).</li>
+            <li>
+              <tt>xlink:role</tt> supports any string (i.e. does not have to be a namespaced resource).
+         This mechanism can, of course, still be used and we shall promote it where STM
+         benefits from it</li>
+            <li>The <tt>to</tt> and <tt>from</tt> attributes point to IDs rather than labels</li>
+            <li>The xlink namespace is not used</li>
+            <li>It is not intended to create independent linkbases, although some collections of
+         links may have this property and stand outside the documents they link to</li>
+          </ul>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attribute name="from" type="namespaceRefType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The starting point of an arc</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="to" type="namespaceRefType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The endpoint of an arc</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ref" type="namespaceRefType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">An ID referenced within a locator</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="role" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The role of the link. Xlink adds semantics through a
+          URI; we shall not be this strict. We shall not normally use this mechanism
+          and use dictionaries instead</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="href" type="xsd:anyURI">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The target of the (locator) link, outside the document</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="type">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The type of the link</div>
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="extended">
+              <xsd:annotation>
+                <xsd:documentation>
+                  <div class="summary">A container for locators</div>
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="locator">
+              <xsd:annotation>
+                <xsd:documentation>
+                  <div class="summary">A link to an element</div>
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="arc">
+              <xsd:annotation>
+                <xsd:documentation>
+                  <div class="summary">A labelled link</div>
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="summary">References</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType name="namespaceRefType" id="st.namespaceRefType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+         A string referencing a dictionary, units, convention or other metadata.
+      </div>
+        <div class="description">
+          <p>A string referencing a dictionary, units, convention or other
+      metadata. The namespace is optional but recommended where possible</p>
+          <p>Note: this convention is only used within STM-ML and related languages;
+      it is NOT a URI.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;list&gt;
+&lt;!-- dictRef is of namespaceRefType --&gt;
+  &lt;scalar dictRef="chem:mpt"&gt;123&lt;/scalar&gt;
+&lt;!-- error --&gt;
+  &lt;scalar dictRef="mpt23"&gt;123&lt;/scalar&gt;
+&lt;/list&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[A-Za-z][A-Za-z0-9_]*(:[A-Za-z][A-Za-z0-9_]*)?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="refType" id="st.refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A reference to an existing element</div>
+        <div class="description">
+          <p>A reference to an existing element in the document.
+            The target of the
+            ref attribute (which may be namepsaced) must exist. The test for validity
+            will normally occur in the element's <tt>appinfo</tt>
+          </p>
+          <p>Any DOM Node created from this element will normally be a <i>reference</i>
+            to another Node, so that if the target node is modified a the dereferenced
+            content is modified. At present there are no deep copy semantics hardcoded
+            into the schema.</p>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="idType"/>
+  </xsd:simpleType>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="heading">General information components</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="heading">General components</div>
+      <div class="description">
+        <p>STM-ML provides a very small number of abstract elements to capture
+    frequently encountered concepts in STM documents. There are no predetermined
+    semantics or ontology; it is expected that descriptive metadata
+    will be added through dictionaries.
+    </p>
+        <p>All elements can contain any element children and can carry the common
+    STM attributes. Currently there are the following:</p>
+        <ul>
+          <li>
+            <a href="el.object">object</a>. Almost anything - concrete, abstract, representable by
+    a noun. Objects can have properties added through <a href="el.scalar">scalar</a>, etc.
+    </li>
+          <li>
+            <a href="el.action">action</a>. Represents an action performed during a scientific narrative.
+    It has attributes describing a time-line and conditions so that a procedure could be replayed.
+    It has a container <a href="el.actionList">actionList</a> which shares these attributes
+    and which can describe sets of actions.
+    </li>
+          <li>
+            <a href="el.observation">observation</a>. Contains narrative or other elements describing
+    an observation, planned or unplanned</li>
+        </ul>
+      </div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="action" id="el.action">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An action which might occur in scientific data or narrative.</div>
+        <div class="description">
+          <p>An action which might occur in scientific data or narrative.
+      The definition is deliberately vague, intending to collect examples of
+      possible usage. Thus an action could be addition of materials,
+      measurement, application of heat or radiation.
+      The content model is unrestricted. <tt>action</tt> iself is
+      normally a child of <a href="#el.actionList">actionList</a>
+          </p>
+          <p>The start, end and duration attributes should be interpreted as
+      </p>
+          <ul>
+            <li>XSD dateTimes and XSD durations. This allows precise recording of
+      time of day, etc, or duration
+      after start of actionList. A <tt>convention="xsd"</tt> attribute should be used
+      to enforce XSD.</li>
+            <li>a numerical value, with a units attribute linked to a dictionary.</li>
+            <li>a human-readable string (unlikely to be machine processable)</li>
+          </ul>
+          <p>
+            <tt>startCondition</tt> and <tt>endCondition</tt>
+      values are not constrained, which allows XSL-like <tt>test</tt> attribute values.
+      The semantics of the conditions are yet to be defined and at present are simply
+      human readable.
+      </p>
+          <p>The order of the <tt>action</tt> elements in the document may, but will not always, define
+      the order that they actually occur in.</p>
+          <p>A delay can be shown by an <tt>action</tt> with no content. Repeated actions or
+      actionLists are indicated through the count attribute.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;actionList title="boiling two eggs for breakfast"&gt;
+  &lt;!-- start cooking at 9am --&gt;
+  &lt;action title="turn on heat" start="T09:00:00" convention="xsd"/&gt;
+  &lt;!-- human readable description of time to start action --&gt;
+  &lt;action title="put egg into pan" startCondition="water is boiling" count="2"/&gt;
+  &lt;!-- the duration is expressed in ISO8601 format --&gt;
+  &lt;action title="boil eggs for 4 minutes" duration="4" units="units:min"/&gt;
+  &lt;!-- action immediately follows last action --&gt;
+  &lt;action title="remove egg from pan" count="1"/&gt;
+  &lt;action title="boil second egg for a bit longer" duration="about half a minute"/&gt;
+  &lt;!-- action immediately follows last action --&gt;
+  &lt;action title="remove egg from pan" count="1"/&gt;
+&lt;/actionList&gt;
+
+         </pre>
+        </div>
+        <div class="example">
+          <pre>
+&lt;actionList title="preparation of silanols"&gt;
+  &lt;p&gt;This is a conversion of a chemical synthesis to STM-ML. We
+  have deliberately not marked up the chemistry in this example!&lt;/p&gt;
+  &lt;action title="step2"&gt;
+    &lt;p&gt;Take 1 mmol of the diol and dissolve in dioxan in
+      &lt;object title="flask"&gt;
+        &lt;scalar title="volume" units="units:ml"&gt;25&lt;/scalar&gt;
+      &lt;/object&gt;
+    &lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step2"&gt;
+    &lt;p&gt;Place flask in water bath with magnetic stirrer&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;!-- wait until certain condition --&gt;
+  &lt;actionList endCondition="bath temperature stabilised"/&gt;
+  &lt;action title="step3"&gt;
+    &lt;p&gt;Add 0.5 ml 1 M H2SO4&lt;/p&gt;
+  &lt;/action&gt;
+
+  &lt;!-- carry out reaction --&gt;
+  &lt;actionList endCondition="reaction complete; no diol spot remains on TLC"&gt;
+    &lt;actionList title="check tlc"&gt;
+      &lt;!-- wait for half an hour --&gt;
+      &lt;action duration="half an hour"/&gt;
+      &lt;action title="tlc"&gt;
+        &lt;p&gt;extract solution and check diol spot on TLC&lt;/p&gt;
+      &lt;/action&gt;
+    &lt;/actionList&gt;
+  &lt;/actionList&gt;
+
+  &lt;!-- work up reaction --&gt;
+  &lt;action title="step5"&gt;
+    &lt;p&gt;Add 10 ml water to flask&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step6"&gt;
+    &lt;p&gt;Neutralize acid with 10% NaHCO3&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step7" count="3"&gt;
+    &lt;p&gt;Extract with 10ml ether&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step8"&gt;
+    &lt;p&gt;Combine ether layers&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step9" count="2"&gt;
+    &lt;p&gt;Wash ether with 10 ml water&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step10"&gt;
+    &lt;p&gt;Wash ether with 10 ml saturated NaCl&lt;/p&gt;
+  &lt;/action&gt;
+  &lt;action title="step11"&gt;
+    &lt;p&gt;Dry over anhydrous Na2SO4 and remove solvent on rotary evaporator&lt;/p&gt;
+  &lt;/action&gt;
+&lt;/actionList&gt;
+
+         </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attributeGroup ref="actionGroup"/>
+      <xsd:attribute name="type" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The type of the action; semantics are not controlled.</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="actionList" id="el.actionList">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A container for a group of <a href="el.action">actions</a>
+        </div>
+        <div class="description">
+          <p>
+            <tt>ActionList</tt> contains a series of <tt>action</tt>s or
+        nested <tt>actionList</tt>s.</p>
+        </div>
+        <div class="example">See examples in <a href="el.action">action</a>
+        </div>
+        <div class="example">
+          <pre>
+&lt;!-- demonstrating parallel and sequential actions --&gt;
+&lt;actionList order="parallel" endCondition="all food cooked"&gt;
+  &lt;!-- meat and potatoes are cooked in parallel --&gt;
+  &lt;actionList title="meat"&gt;
+    &lt;action title="cook" endCondition="cooked"&gt;
+      &lt;p&gt;Roast meat&lt;/p&gt;
+    &lt;/action&gt;
+    &lt;action&gt;&lt;p&gt;Keep warm in oven&lt;/p&gt;&lt;/action&gt;
+  &lt;/actionList&gt;
+  &lt;actionList title="vegetables"&gt;
+    &lt;actionList title="cookVeg" endCondition="cooked"&gt;
+      &lt;action title="boil water" endCondition="water boiling"&gt;
+        &lt;p&gt;Heat water&lt;/p&gt;
+      &lt;/action&gt;
+      &lt;action title="cook" endCondition="potatoes cooked"&gt;
+        &lt;p&gt;Cook potatoes&lt;/p&gt;
+      &lt;/action&gt;
+    &lt;/actionList&gt;
+    &lt;action&gt;&lt;p&gt;Keep warm in oven&lt;/p&gt;&lt;/action&gt;
+  &lt;/actionList&gt;
+&lt;/actionList&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attributeGroup ref="actionGroup"/>
+      <xsd:attribute name="type" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The type of the actionList; no defined semantics</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="order" default="sequential">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="description">Describes whether child elements are sequential or parallel</div>
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="sequential"/>
+            <xsd:enumeration value="parallel"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="object" id="el.object">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An object which might occur in scientific data or narrative</div>
+        <div class="description">
+          <p>Deliberately vague. Thus an instrument might be built from sub component
+        objects, or a program could be composed of smaller modules (objects).
+        Unrestricted content model</p>
+        </div>
+        <div class="example">
+          <pre>&lt;object title="frog" type="amphibian" count="5"&gt;
+  &lt;scalar dataType="xsd:float" title="length" units="unit:cm"&gt;5&lt;/scalar&gt;
+  &lt;obj1/&gt;
+&lt;/object&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attribute name="type" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">Type of the object. Uncontrolled semantics</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="count" type="countType"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="observation" id="el.observation">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An observation or occurrence</div>
+        <div class="description">
+          <p>A container for any events that
+        need to be recorded, whether planned or not. They can include notes,
+        measurements, conditions that may be referenced elsewhere, etc. There are
+        no controlled semantics </p>
+          <div class="example">
+            <pre>&lt;observation type="ornithology"&gt;
+  &lt;object title="sparrow" count="3"/&gt;
+  &lt;observ/&gt;
+&lt;/observation&gt;
+</pre>
+          </div>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attribute name="type" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">Type of observation (uncontrolled vocabulary)</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="count" type="countType"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="stmml" id="el.stmml">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An element to hold stmml data.</div>
+        <div class="description">
+          <p>
+            <tt>stmml</tt> holds stmml data under a single
+            generic container. Other namespaces may be present as children.
+            No semantics implied.
+         </p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;stmml&gt;
+  &lt;actionList&gt;
+    &lt;action&gt;&lt;/action&gt;
+  &lt;/actionList&gt;
+  &lt;object&gt;&lt;/object&gt;
+  &lt;observation&gt;&lt;/observation&gt;
+
+&lt;!-- ==================== DICTIONARY =========== --&gt;
+
+  &lt;dictionary&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;&lt;/documentation&gt;
+      &lt;appinfo&gt;&lt;/appinfo&gt;
+    &lt;/annotation&gt;
+    &lt;entry term="foo"&gt;
+      &lt;definition&gt;&lt;/definition&gt;
+      &lt;alternative&gt;&lt;/alternative&gt;
+      &lt;description&gt;&lt;/description&gt;
+      &lt;enumeration&gt;&lt;/enumeration&gt;
+      &lt;relatedEntry&gt;&lt;/relatedEntry&gt;
+    &lt;/entry&gt;
+  &lt;/dictionary&gt;
+
+&lt;!-- =================  METADATA ================== --&gt;
+
+  &lt;metadataList&gt;
+    &lt;metadata&gt;&lt;/metadata&gt;
+  &lt;/metadataList&gt;
+
+&lt;!-- =================  SCIENTIFIC UNITS ================== --&gt;
+
+  &lt;unitList&gt;
+    &lt;unitType id="ut1" name="u"&gt;
+      &lt;dimension name="mass"&gt;&lt;/dimension&gt;
+    &lt;/unitType&gt;
+    &lt;unit id="u1"&gt;&lt;/unit&gt;
+  &lt;/unitList&gt;
+
+&lt;/stmml&gt;
+
+
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="subheading">Dictionary components</div>
+      <div class="description">
+        <p>Dictionaries are a major part of STM-ML and supported as follows:</p>
+        <p>The dictionary itself:</p>
+        <ul>
+          <li>
+            <a href="el.dictionary">dictionary</a>. This element defines a dictionary
+    and is often the root element (though a data instance might also be combined
+    with a dictionary). The dictionary play a similar role to a simple schema, by defining
+    data types and other constraints (such as enumerations). By transforming a dictionary to
+    schema format, schema-based tools can be used for validation. A dictionary is
+    normally composed of <a href="el.entry">entry</a>s.</li>
+          <li>
+            <a href="el.entry">entry</a>. An entry contanins information which <em>describes</em>
+    or <em>constrains</em> elements in a data instance. The link is made through a
+    <a href="st.dictRef">dictRef</a> attribute on the data element.
+    Descriptive information can apply to any type of element (not necessarily
+    part of or derived from the STM Schema). Constraints are similar to those in XML Schemas
+    and use the same vocabulary (dataTypes, value ranges, enumerations, patterns, etc.). They normally
+    apply to elements from the STM Schema or derived from it.<br/>
+    In addition entrys can constrain elements to have the same
+    higher-level structures and constraints defined by STM Schema. Thus entrys can require a
+    data element to be a matrix, of a given type, with fixed number os rows and columns. These
+    constraints are usually attributes on the entry element, which therefore maps
+    directly onto the instance. Every entry has a mandatory <tt>term</tt> attribute
+    which is the formal text string representing the concept. This string can contain any allowed
+    XML characters (e.g. greek characters) but not markup (e.g. MathML or CML).</li>
+          <li>
+            <a href="el.definition">definition</a>. An almost mandatory child element of entry, giving
+    a formal definition of the term</li>
+          <li>
+            <a href="el.description">description</a>. Additional descriptive informati&gt;on for an entry.
+    This can contain any content, often HTML, but also MathML, CML for description of
+    equations, chemical formulae, etc.</li>
+          <li>
+            <a href="el.alternative">alternative</a>. Alternative strings for describing the
+    concept. These can be any of the stnadard lexical and terminological data categories
+    such as synonyms, abbreviations, homonyms, etc. (see ISO12620 for a full range).</li>
+          <li>
+            <a href="el.enumeration">enumeration</a>. A list of allowed values for the data
+    element (or elements in arrays, matrices).</li>
+          <li>
+            <a href="el.relatedEntry">relatedEntry</a>. A related entry. Sometimes this is
+    descriptive (e.g. "seeAlso" provides additional information on related concepts).
+    It can also be used for constraints, and there is a small controlled vocabulary
+    of relationships, but no universal syntax. We
+    support parentage (e.g. through "partitiveParent" = "partOf"). In principle this can
+    be used with <a href="el.appinfo">appinfo</a> to provide algorithmically constructed
+    relationships.
+    </li>
+          <li>
+            <em>attributes</em>. A wide range of constraints is provided through attributes,
+    several being similar to facets on XML Schema datatypes:
+    <ul>
+              <li>
+                <b>rows</b> and <b>columns</b>, the structure of the data element.</li>
+              <li>
+                <b>recommendedUnits</b>, <b>units</b> and <b>unitType</b>, the units of the data element.</li>
+              <li>
+                <b>minExclusive</b>, <b>minInclusive</b>, <b>maxExclusive</b> and <b>maxInclusive</b>,
+    the value of the data element.</li>
+              <li>
+                <b>totalDigits</b>, <b>fractionDigits</b>, <b>length</b>, <b>maxLength</b>, <b>minLength</b>
+    and <b>pattern</b>. The lexical form of the  data element.</li>
+            </ul>
+          </li>
+          <li>
+            <a href="el.annotation">annotation</a>. Similar to XML Schema, this has children
+    <a href="el.documentation">documentation</a> for information about the entry (normally
+    curatorial) and <a href="el.appinfo">appinfo</a> to describe entries and constraints
+    in machine-processable fashion.
+    .</li>
+        </ul>
+      </div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="dictionary" id="el.dictionary">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A dictionary</div>
+        <div class="description">
+          <p>A dictionary is a container for <a href="el.entry">entry</a>
+        elements. Dictionaries can also contain unit-related information.</p>
+          <p>The dictRef attribute on a <tt>dictionary</tt> element
+         sets a namespace-like prefix allowing the dictionary to be referenced from
+         within the document. In general dictionaries are
+         referenced from an element using the
+         <a href="gp.dictRefGroup">dictRef</a> attribute.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;stm:dictionary xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"&gt;
+  &lt;stm:entry id="a001" term="Amplitude for charge density mixing"
+    dataType="stm:decimal"
+    units="arbitrary"&gt;
+    &lt;stm:annotation&gt;
+      &lt;stm:documentation&gt;
+        &lt;div class="summary"&gt;Amplitude for charge density mixing&lt;/div&gt;
+        &lt;div class="description"&gt;Not yet filled in...&lt;/div&gt;
+      &lt;/stm:documentation&gt;
+    &lt;/stm:annotation&gt;
+    &lt;stm:alternative type="abbreviation"&gt;CDMixAmp&lt;/stm:alternative&gt;
+  &lt;/stm:entry&gt;
+&lt;/stm:dictionary&gt;
+
+        </pre>
+        </div>
+        <div class="example">
+          <p>
+            <tt>dictionary</tt> can be used in an instance
+        document to reference the dictionary used. Example:</p>
+          <pre>
+&lt;list&gt;
+  &lt;dictionary
+     dictRef="core" href="../dictionary/coreDict.xml"/&gt;
+&lt;/list&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="unitList" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+              <div class="description">
+                <p>This is so that a reference to a UnitList can be put in a dictionary.</p>
+              </div>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="annotation" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="description" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="entry" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attribute name="href" type="xsd:anyURI">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">URI giving the location of the document. Mandatory if <tt>dictRef</tt>
+            present.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="entry" id="el.entry">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A dictionary entry</div>
+        <div class="example">
+          <pre>
+&lt;entry id="a003" term="alpha"
+  dataType="float"
+  minInclusive="0.0"
+  maxInclusive="180.0"
+  recommendedUnits="degrees"&gt;
+  &lt;definition&gt;The alpha cell angle&lt;/definition&gt;
+&lt;/entry&gt;
+
+         </pre>
+        </div>
+        <div class="example">
+          <pre>
+&lt;entry id="a003"
+  term="matrix1"
+  dataType="float"
+  rows="3"
+  columns="4"
+  unitType="unit:length"
+  minInclusive="0.0"
+  maxInclusive="100.0"
+  recommendedUnits="unit:m"
+  totalDigits="8"
+  fractionDigits="3"&gt;
+    &lt;definition&gt;A matrix of lengths&lt;/definition&gt;
+    &lt;description&gt;A data instance will have a matrix which points
+  to this entry (e.g. dictRef="foo:matrix1"). The matrix must
+  be 3*4, composed of floats in 8.3 format, of type length,
+  values between 0 and 100 and with recommended units metres.
+    &lt;/description&gt;
+&lt;/entry&gt;
+
+         </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="definition" minOccurs="0"/>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+          <xsd:element ref="alternative"/>
+          <xsd:element ref="annotation"/>
+          <!-- <xsd:element ref="definition"/> -->
+          <xsd:element ref="description"/>
+          <xsd:element ref="enumeration"/>
+          <xsd:element ref="relatedEntry"/>
+        </xsd:choice>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_convGroup"/>
+      <xsd:attribute name="dataType" type="xsd:string"/>
+      <xsd:attribute name="rows" type="xsd:positiveInteger" default="1"/>
+      <xsd:attribute name="columns" type="xsd:positiveInteger" default="1"/>
+      <xsd:attribute name="recommendedUnits" type="unitsType"/>
+      <xsd:attribute name="unitType" type="xsd:string"/>
+      <xsd:attribute name="minExclusive" type="xsd:decimal"/>
+      <xsd:attribute name="minInclusive" type="xsd:decimal"/>
+      <xsd:attribute name="maxExclusive" type="xsd:decimal"/>
+      <xsd:attribute name="maxInclusive" type="xsd:decimal"/>
+      <xsd:attribute name="totalDigits" type="xsd:positiveInteger"/>
+      <xsd:attribute name="fractionDigits" type="xsd:nonNegativeInteger"/>
+      <xsd:attribute name="length" type="xsd:nonNegativeInteger"/>
+      <xsd:attribute name="minLength" type="xsd:nonNegativeInteger"/>
+      <xsd:attribute name="maxLength" type="xsd:positiveInteger"/>
+      <xsd:attribute name="units" type="unitsType"/>
+      <xsd:attribute name="whiteSpace" type="xsd:string"/>
+      <xsd:attribute name="pattern" type="xsd:string"/>
+      <xsd:attribute name="term" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="definition" id="el.definition">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>The definition for a dictionary entry, scientific units, etc.</p>
+        </div>
+        <div class="description">
+          <p>The definition should be a short nounal phrase definining the
+         subject of the entry. Definitions should not include commentary, implementations,
+         equations or formulae (unless the subject is one of these) or examples. The
+         <tt>description</tt> element can be used for these.</p>
+          <p>The definition can be in any markup language, but normally XHTML will be used,
+        perhaps with links to other XML namespaces such as CML for chemistry.</p>
+        </div>
+        <div class="example">
+          <em>From the IUPAC Dictionary of Medicinal Chemistry</em>
+          <br/>
+          <pre>
+&lt;entry id="a7" term="Allosteric enzyme"&gt;
+  &lt;definition&gt;An &lt;a href="#e3"&gt;enzyme&lt;/a&gt;
+that contains a region to which small, regulatory molecules
+("effectors") may bind in addition to and separate from the
+substrate binding site and thereby affect the catalytic
+activity.
+  &lt;/definition&gt;
+  &lt;description&gt;On binding the effector, the catalytic activity of the
+&lt;strong&gt;enzyme&lt;/strong&gt; towards the substrate may be enhanced, in
+which case the effector is an activator, or reduced, in which case
+it is a de-activator or inhibitor.
+  &lt;/description&gt;
+&lt;/entry&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="sourceGroup"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="description" id="el.description">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">Descriptive information in a dictionary entry, etc.</div>
+        <div class="description">
+          <p>Entries should have at least one separate <a href="el.definition">definition</a>s.
+         <tt>description</tt> is then used for most of the other information, including
+         examples. The <tt>class</tt> attribute has an uncontrolled vocabulary and
+         can be used to clarify the purposes of the <tt>description</tt>
+         elements.</p>
+        </div>
+        <div class="example">
+          <em>From IUPAC Dictionary of Medicinal Chemistry</em>
+          <pre>
+&lt;entry id="a7" term="Allosteric enzyme"&gt;
+  &lt;definition&gt;An &lt;a href="#e3"&gt;enzyme&lt;/a&gt;
+that contains a region to which small, regulatory molecules
+("effectors") may bind in addition to and separate from the
+substrate binding site and thereby affect the catalytic
+activity.
+  &lt;/definition&gt;
+  &lt;description&gt;On binding the effector, the catalytic activity of the
+&lt;strong&gt;enzyme&lt;/strong&gt; towards the substrate may be enhanced, in
+which case the effector is an activator, or reduced, in which case
+it is a de-activator or inhibitor.
+  &lt;/description&gt;
+&lt;/entry&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="sourceGroup"/>
+      <xsd:attribute name="class" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="description">
+              <p>The type of this information. This is not controlled, but examples
+            might include:</p>
+              <ul>
+                <li>description</li>
+                <li>summary</li>
+                <li>note</li>
+                <li>usage</li>
+                <li>qualifier</li>
+              </ul>
+            </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="enumeration" id="el.enumeration">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An enumeration of string values associated
+        with an <a href="el.entry">entry</a>
+        </div>
+        <div class="description">
+          <p>An enumeration of string values. Used where a dictionary entry constrains
+        the possible values in a document instance. The dataTypes (if any) must all be
+        identical and are defined by the dataType of the containing element.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;entry term="crystal system" id="cryst1" dataType="string"&gt;
+  &lt;definition&gt;A crystal system&lt;/definition&gt;
+  &lt;enumeration value="triclinic"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;No constraints on lengths and angles&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+  &lt;enumeration value="monoclinic"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;Two cell angles are right angles; no other constraints&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+  &lt;enumeration value="orthorhombic"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;All three angles are right angles; no other constraints&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+  &lt;enumeration value="tetragonal"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;Fourfold axis of symmetry; All three angles are right angles; two equal cell lengths; no other constraints&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+  &lt;enumeration value="trigonal"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;Threefold axis of symmetry; Two angles are right angles; one is 120 degrees; two equal lengths; no other constraints&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+  &lt;enumeration value="hexagonal"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;Sixfold axis of symmetry; Two angles are right angles; one is 120 degrees; two equal lengths; no other constraints&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+  &lt;enumeration value="cubic"&gt;
+    &lt;annotation&gt;
+      &lt;documentation&gt;
+        &lt;div class="summary"&gt;All three angles are right angles; all cell lengths are equal&lt;/div&gt;
+      &lt;/documentation&gt;
+    &lt;/annotation&gt;
+  &lt;/enumeration&gt;
+&lt;/entry&gt;
+
+           </pre>
+        </div>
+        <div class="description">
+          <p>An enumeration of string values. The dataTypes (if any) must all be
+        identical and are defined by the dataType of the containing element.</p>
+          <p>Documentation can be added through an <a href="el.enumeration">enumeration</a>
+        child</p>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="annotation" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="value" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The value of the enumerated element.</div>
+            <div class="description">
+            Must be compatible
+            with the dataType of the containing element (not schema-checkable directly
+            but possible if dictionary is transformed to schema).</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="alternative" id="el.alternative">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>An alternative name for an entry</p>
+        </div>
+        <div class="description">
+          <p>At present a child of <a href="#el.entry">entry</a> which represents
+           an alternative string that refers to the concept. There is a partial controlled
+           vocabulary in <tt>alternativeType</tt> with values such as :
+         </p>
+          <ul>
+            <li>synonym</li>
+            <li>acronym</li>
+            <li>abbreviation</li>
+          </ul>
+        </div>
+        <div class="example">
+          <pre>
+ &lt;entry term="ammonia" id="a1"&gt;
+   &lt;alternative type="synonym"&gt;Spirits of hartshorn&lt;/alternative&gt;
+   &lt;alternative type="my:formula"&gt;NH3&lt;/alternative&gt;
+ &lt;/entry&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">the type of an
+          <a href="#el.alternative">alternative</a> element.
+        </div>
+          <div class="description">
+            <p>
+              <tt>alternativeType</tt> represents a the type of an
+            <a href="#el.alternative">alternative</a> element.
+          </p>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="type">
+            <xsd:simpleType>
+              <xsd:union>
+                <xsd:simpleType>
+                  <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="synonym"/>
+                    <xsd:enumeration value="quasi-synonym"/>
+                    <xsd:enumeration value="acronym"/>
+                    <xsd:enumeration value="abbreviation"/>
+                    <xsd:enumeration value="homonym"/>
+                    <xsd:enumeration value="identifier"/>
+                  </xsd:restriction>
+                </xsd:simpleType>
+                <xsd:simpleType>
+                  <xsd:restriction base="namespaceRefType"/>
+                </xsd:simpleType>
+              </xsd:union>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="relatedEntry" id="el.relatedEntry">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An entry related in some way to a dictionary entry, scientific units, etc.</div>
+        <div class="description">
+          <p>The range of relationships is not restricted
+        but should include parents, aggregation, seeAlso
+        etc. dataCategories from ISO12620 can be referenced through the <tt>namespaced</tt>
+        mechanism.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;stm:entry id="a14" term="Autoreceptor"
+  xmlns:stm="http://www.xml-cml.org/schema/core"&gt;
+  &lt;stm:definition&gt;An &lt;strong&gt;autoreceptor&lt;/strong&gt;, present at a nerve ending, is
+    a &lt;a href="#r1"&gt;receptor&lt;/a&gt;
+    that regulates, via positive or negative feedback processes, the
+    synthesis and/or release of its own physiological ligand.
+  &lt;/stm:definition&gt;
+  &lt;stm:relatedEntry type="seeAlso" href="#h4"&gt;Heteroreceptor).&lt;/stm:relatedEntry&gt;
+  &lt;stm:relatedEntry type="my:antonym" href="#h4"&gt;antiheteroreceptor).&lt;/stm:relatedEntry&gt;
+  &lt;relatedEntry1/&gt;
+&lt;/stm:entry&gt;
+
+               </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="type">
+        <xsd:simpleType>
+          <xsd:annotation>
+            <xsd:documentation>
+              <div class="description">
+                <p>
+                  <tt>relatedEntryType</tt> represents a the type of relationship in a
+                     <a href="#el.relatedEntry">relatedEntry</a> element.
+                  </p>
+              </div>
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:union>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="parent"/>
+                <xsd:enumeration value="partitiveParent"/>
+                <xsd:enumeration value="child"/>
+                <xsd:enumeration value="partitiveChild"/>
+                <xsd:enumeration value="related"/>
+                <xsd:enumeration value="synonym"/>
+                <xsd:enumeration value="quasi-synonym"/>
+                <xsd:enumeration value="antonym"/>
+                <xsd:enumeration value="homonym"/>
+                <xsd:enumeration value="see"/>
+                <xsd:enumeration value="seeAlso"/>
+                <xsd:enumeration value="abbreviation"/>
+                <xsd:enumeration value="acronym"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType>
+              <xsd:restriction base="namespaceRefType"/>
+            </xsd:simpleType>
+          </xsd:union>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="href" type="xsd:anyURI"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="annotation" id="el.annotation">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>A documentation container similar to <tt>annotation</tt> in XML Schema.</p>
+        </div>
+        <div class="description">
+          <p>A documentation container similar to <tt>annotation</tt> in XML Schema.
+        At present this is experimental and designed to be used for dictionaries, units, etc.
+        One approach is to convert these into XML Schemas when the <tt>documentation</tt>
+        and <tt>appinfo</tt> children will emerge in their correct position in the
+        derived schema.</p>
+          <p>It is possible that this may develop as a useful tool for annotating components
+        of complex objects such as molecules. </p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;entry term="matrix"&gt;
+  &lt;annotation&gt;
+    &lt;documentation&gt;This refers to mathematical matrices&lt;/documentation&gt;
+    &lt;appinfo&gt;... some code to describe and support matrices ...&lt;/appinfo&gt;
+  &lt;/annotation&gt;
+&lt;/entry&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="documentation"/>
+        <xsd:element ref="appinfo"/>
+      </xsd:choice>
+      <xsd:attribute name="source" type="xsd:anyURI"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="documentation" id="el.documentation">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">Documentation in the <a href="el.annotation">annotation</a> of an <a href="el.entry">entry</a>
+        </div>
+        <div class="description">
+          <p>A container similar to <tt>documentation</tt> in XML Schema.
+        This is NOT part of the textual content of an entry but is designed to
+        support the transformation of dictionary entrys into schemas for validation.
+        This is experimental and should only be used for dictionaries, units, etc.
+        One approach is to convert these into XML Schemas when the <tt>documentation</tt>
+        and <tt>appinfo</tt> children will emerge in their correct position in the
+        derived schema.</p>
+          <p>Do NOT confuse documentation with the <a href="el.definition">definition</a>
+        or the <a href="el.definition">definition</a> which are part of the content
+        of the dictionary</p>
+          <p>If will probably only be used when there is significant <a href="el.appinfo">appinfo</a>
+        in the entry or where the entry defines an XSD-like datatype of an element in the document.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;stm:documentation id="source"
+xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"&gt;
+Transcribed from IUPAC website
+&lt;/stm:documentation&gt;
+
+           </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="sourceGroup"/>
+      <xsd:attributeGroup ref="idGroup"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="appinfo" id="el.appinfo">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>A container similar to <tt>appinfo</tt> in XML Schema.</p>
+        </div>
+        <div class="description">
+          <p>A container for machine processable documentation for an entry.
+           This is likely to be platform and/or language specific. It is possible
+           that XSLT, RDF or XBL will emerge as generic languages</p>
+          <p>See <a href="el.annotation">annotation</a> and <a href="el.documentation">documentation</a> for further information</p>
+        </div>
+        <div class="example">
+          <p>An example in XSLT where an element <tt>foo</tt> calls a bespoke
+         template</p>.
+         <pre>
+&lt;s:appinfo
+  xmlns:s="http://www.xml-cml.org/schema/core"
+  xmlns="http://www.w3.org/1999/XSL/Transform"&gt;
+  &lt;template match="foo"&gt;
+    &lt;call-template name="processFoo"/&gt;
+  &lt;/template&gt;
+&lt;/s:appinfo&gt;
+
+         </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType mixed="true">
+      <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+        <xsd:any processContents="lax"/>
+      </xsd:sequence>
+      <xsd:attribute name="source" type="xsd:anyURI"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:attributeGroup name="dictRefGroup" id="attGp.dictRefGroup">
+    <xsd:attribute name="dictRef" type="namespaceRefType" id="att.dictRef">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">
+            <p>A reference to a dictionary entry.</p>
+          </div>
+          <div class="description">
+            <p>Elements in data instances such as <a href="el.scalar">scalar</a> may have a
+         <tt>dictRef</tt> attribute to point to an entry in a dictionary. To avoid
+         excessive use of (mutable) filenames and URIs we recommend a namespace
+         prefix, mapped to a namespace URI in the normal manner. In this case,
+         of course, the namespace URI must point to a real XML document containing
+         <a href="el.entry">entry</a> elements and validated against STM-ML Schema.</p>
+            <p>Where there is concern about the dictionary becoming separated from the document
+         the dictionary entries can be physically included as part of the data instance
+         and the normal XPointer addressing mechanism can be used.</p>
+            <p>This attribute can also be used on <a href="el.dictionary">dictionary</a>
+         elements to define the namespace prefix</p>
+          </div>
+          <div class="example">
+            <pre>
+&lt;scalar dataType="xsd:float" title="surfaceArea"
+  dictRef="cmlPhys:surfArea"
+  xmlns:cmlPhys="http://www.xml-cml.org/dict/physical"
+  units="units:cm2"&gt;50&lt;/scalar&gt;
+
+           </pre>
+          </div>
+          <div class="example">
+            <pre>
+&lt;stm:list xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"&gt;
+  &lt;stm:observation&gt;
+    &lt;p&gt;We observed &lt;object count="3" dictRef="#p1"/&gt;
+      constructing dwellings of different material&lt;/p&gt;
+  &lt;/stm:observation&gt;
+  &lt;stm:entry id="p1" term="pig"&gt;
+    &lt;stm:definition&gt;A domesticated animal.&lt;/stm:definition&gt;
+    &lt;stm:description&gt;Predators include wolves&lt;/stm:description&gt;
+    &lt;stm:description class="scientificName"&gt;Sus scrofa&lt;/stm:description&gt;
+  &lt;/stm:entry&gt;
+&lt;/stm:list&gt;
+
+           </pre>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="subheading">Metadata</div>
+      <div class="description">
+        <p>STM-ML supports metadata through the element
+    <a href="el.metadata">metadata</a>. If necessary
+    several of these can be contained in
+    a <a href="el.metadataList">metadataList</a> element.
+    </p>
+      </div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="metadata" id="el.metadata">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A general container for metadata</div>
+        <div class="description">
+          <p>A general container for metadata, including at least
+      Dublin Core (DC) and CML-specific metadata</p>
+          <p>In its simple form each element provides a name and content in a similar
+      fashion to the <tt>meta</tt> element in HTML. <tt>metadata</tt> may have simpleContent
+      (i.e. a string for adding further information - this is not controlled).</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;list&gt;
+  &lt;metadataList&gt;
+    &lt;metadata name="dc:coverage" content="Europe"/&gt;
+    &lt;metadata name="dc:description" content="Ornithological chemistry"/&gt;
+    &lt;metadata name="dc:identifier"  content="ISBN:1234-5678"/&gt;
+    &lt;metadata name="dc:format" content="printed"/&gt;
+    &lt;metadata name="dc:relation" content="abc:def123"/&gt;
+    &lt;metadata name="dc:rights" content="licence:GPL"/&gt;
+    &lt;metadata name="dc:subject" content="Informatics"/&gt;
+    &lt;metadata name="dc:title" content="birds"/&gt;
+    &lt;metadata name="dc:type" content="bird books on chemistry"/&gt;
+    &lt;metadata name="dc:contributor" content="Tux Penguin"/&gt;
+    &lt;metadata name="dc:creator" content="author"/&gt;
+    &lt;metadata name="dc:publisher" content="Penguinone publishing"/&gt;
+    &lt;metadata name="dc:source" content="penguinPub"/&gt;
+    &lt;metadata name="dc:language" content="en-GB"/&gt;
+    &lt;metadata name="dc:date" content="1752-09-10"/&gt;
+  &lt;/metadataList&gt;
+  &lt;metadataList&gt;
+    &lt;metadata name="cmlm:safety" content="mostly harmless"/&gt;
+    &lt;metadata name="cmlm:insilico" content="electronically produced"/&gt;
+    &lt;metadata name="cmlm:structure" content="penguinone"/&gt;
+    &lt;metadata name="cmlm:reaction" content="synthesis of penguinone"/&gt;
+    &lt;metadata name="cmlm:identifier" content="smiles:O=C1C=C(C)C(C)(C)C(C)=C1"/&gt;
+  &lt;/metadataList&gt;
+&lt;/list&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="name" type="metadataType">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">The metadata type</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="content" type="xsd:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <div class="summary">The metadata</div>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="metadataList" id="el.metadataList">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A general container for metadata elements</div>
+        <div class="example">
+          <pre>&lt;list&gt;
+  &lt;metadataList&gt;
+    &lt;metadata name="dc:coverage" content="Europe"/&gt;
+    &lt;metadata name="dc:description" content="Ornithological chemistry"/&gt;
+    &lt;metadata name="dc:identifier"  content="ISBN:1234-5678"/&gt;
+    &lt;metadata name="dc:format" content="printed"/&gt;
+    &lt;metadata name="dc:relation" content="abc:def123"/&gt;
+    &lt;metadata name="dc:rights" content="licence:GPL"/&gt;
+    &lt;metadata name="dc:subject" content="Informatics"/&gt;
+    &lt;metadata name="dc:title" content="birds"/&gt;
+    &lt;metadata name="dc:type" content="bird books on chemistry"/&gt;
+    &lt;metadata name="dc:contributor" content="Tux Penguin"/&gt;
+    &lt;metadata name="dc:creator" content="author"/&gt;
+    &lt;metadata name="dc:publisher" content="Penguinone publishing"/&gt;
+    &lt;metadata name="dc:source" content="penguinPub"/&gt;
+    &lt;metadata name="dc:language" content="en-GB"/&gt;
+    &lt;metadata name="dc:date" content="1752-09-10"/&gt;
+  &lt;/metadataList&gt;
+  &lt;metadataList&gt;
+    &lt;metadata name="cmlm:safety" content="mostly harmless"/&gt;
+    &lt;metadata name="cmlm:insilico" content="electronically produced"/&gt;
+    &lt;metadata name="cmlm:structure" content="penguinone"/&gt;
+    &lt;metadata name="cmlm:reaction" content="synthesis of penguinone"/&gt;
+    &lt;metadata name="cmlm:identifier" content="smiles:O=C1C=C(C)C(C)(C)C(C)=C1"/&gt;
+  &lt;/metadataList&gt;
+&lt;/list&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="metadata" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:simpleType name="metadataType" id="md.metadataType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="dc:coverage">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">The extent or scope of the
+            content of the resource.</div>
+            <div class="description">Coverage will typically include
+            spatial location (a place name or geographic
+            coordinates), temporal period (a period label, date, or
+            date range) or jurisdiction (such as a named
+            administrative entity). Recommended best practice is to
+            select a value from a controlled vocabulary (for
+            example, the Thesaurus of Geographic Names [TGN]) and
+            that, where appropriate, named places or time periods
+            be used in preference to numeric identifiers such as
+            sets of coordinates or date ranges.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:description">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">An account of the content of the
+            resource.</div>
+            <div class="description">Description may include but is not
+            limited to: an abstract, table of contents, reference
+            to a graphical representation of content or a free-text
+            account of the content.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:identifier">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">An unambiguous reference to the
+            resource within a given context.</div>
+            <div class="description">Recommended best practice is to
+            identify the resource by means of a string or number
+            conforming to a formal identification system. Example
+            formal identification systems include the Uniform
+            Resource Identifier (URI) (including the Uniform
+            Resource Locator (URL)), the Digital Object Identifier
+            (DOI) and the International Standard Book Number
+            (ISBN).
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:format">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">The physical or digital
+            manifestation of the resource.</div>
+            <div class="description">Typically, Format may include the
+            media-type or dimensions of the resource. Format may be
+            used to determine the software, hardware or other
+            equipment needed to display or operate the resource.
+            Examples of dimensions include size and duration.
+            Recommended best practice is to select a value from a
+            controlled vocabulary (for example, the list of
+            Internet Media Types [MIME] defining computer media
+            formats).
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:relation">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">A reference to a related
+            resource.</div>
+            <div class="description">Recommended best practice is to
+            reference the resource by means of a string or number
+            conforming to a formal identification system.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:rights">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">Information about rights held in
+            and over the resource.</div>
+            <div class="description">Typically, a Rights element will
+            contain a rights management statement for the resource,
+            or reference a service providing such information.
+            Rights information often encompasses Intellectual
+            Property Rights (IPR), Copyright, and various Property
+            Rights. If the Rights element is absent, no assumptions
+            can be made about the status of these and other rights
+            with respect to the resource.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:subject">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">The topic of the content of the
+            resource.</div>
+            <div class="description">Typically, a Subject will be
+            expressed as keywords, key phrases or classification
+            codes that describe a topic of the resource.
+            Recommended best practice is to select a value from a
+            controlled vocabulary or formal classification
+            scheme.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:title">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">A name given to the resource.</div>
+            <div class="description">Typically, a Title will be a name by
+            which the resource is formally known.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:type">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">The nature or genre of the
+            content of the resource.</div>
+            <div class="description">Type includes terms describing
+            general categories, functions, genres, or aggregation
+            levels for content. Recommended best practice is to
+            select a value from a controlled vocabulary (for
+            example, the working draft list of Dublin Core Types
+            [DCT1]). To describe the physical or digital
+            manifestation of the resource, use the FORMAT
+            element.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:contributor">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">An entity responsible for making
+            contributions to the content of the resource.</div>
+            <div class="description">Examples of a Contributor include a
+            person, an organisation, or a service. Typically, the
+            name of a Contributor should be used to indicate the
+            entity.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:creator">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">An entity primarily responsible
+            for making the content of the resource.</div>
+            <div class="description">Examples of a Creator include a
+            person, an organisation, or a service. Typically, the
+            name of a Creator should be used to indicate the
+            entity.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:publisher">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">An entity responsible for making
+            the resource available</div>
+            <div class="description">Examples of a Publisher include a
+            person, an organisation, or a service. Typically, the
+            name of a Publisher should be used to indicate the
+            entity.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:source">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">A Reference to a resource from
+            which the present resource is derived.</div>
+            <div class="description">The present resource may be derived
+            from the Source resource in whole or in part.
+            Recommended best practice is to reference the resource
+            by means of a string or number conforming to a formal
+            identification system.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:language">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">A language of the intellectual
+            content of the resource.</div>
+            <div class="description">Recommended best practice for the
+            values of the Language element is defined by RFC 1766
+            [RFC1766] which includes a two-letter Language Code
+            (taken from the ISO 639 standard [ISO639]), followed
+            optionally, by a two-letter Country Code (taken from
+            the ISO 3166 standard [ISO3166]). For example, 'en' for
+            English, 'fr' for French, or 'en-uk' for English used
+            in the United Kingdom.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="dc:date">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">A date associated with an event
+            in the life cycle of the resource.</div>
+            <div class="description">Typically, Date will be associated
+            with the creation or availability of the resource.
+            Recommended best practice for encoding the date value
+            is defined in a profile of ISO 8601 [W3CDTF] and
+            follows the YYYY-MM-DD format.
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="cmlm:safety">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">Entry contains information
+            relating to chemical safety</div>
+            <div class="description">Typically the content will be a
+            reference to a handbook, MSDS, threshhold or other
+            human-readable string
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="cmlm:insilico">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">Part or whole of the information
+            was computer-generated</div>
+            <div class="description">Typically the content will be the
+            name of a method or a program
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="cmlm:structure">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="definition">3D structure included</div>
+            <div class="description">details included
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="cmlm:reaction"/>
+      <xsd:enumeration value="cmlm:identifier"/>
+      <xsd:enumeration value="other"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="heading">Scientific Units</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="dimension" id="el.dimension">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A dimension supporting scientific units</div>
+        <div class="description">
+          <p>This will be primarily used within the defintion of
+        <a href="el.unit">units</a>s.</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;unitType id="energy" name="energy"&gt;
+  &lt;dimension name="length"/&gt;
+  &lt;dimension name="mass"/&gt;
+  &lt;dimension name="time" power="-1"/&gt;
+&lt;/unitType&gt;
+
+
+       </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence/>
+      <xsd:attribute name="name" type="dimensionType" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The type of the dimension</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="power" type="xsd:decimal" default="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">The power to which the dimension should be raised</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:simpleType name="dimensionType" id="st.dimensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">Allowed values for dimension Types (for quantities).</div>
+        <div class="description">
+          <p>These are the 7 types prescribed by the SI system, together
+         with the "dimensionless" type. We intend to be somewhat uncoventional
+         and explore enhanced values of "dimensionless", such as "angle".
+         This may be heretical, but we find the present system impossible to implement
+         in many cases.</p>
+          <p>Used for constructing entries in a dictionary of units</p>
+        </div>
+        <div class="example">
+          <pre>
+&lt;unitType id="energy" name="energy"&gt;
+  &lt;dimension name="length"/&gt;
+  &lt;dimension name="mass"/&gt;
+  &lt;dimension name="time" power="-1"/&gt;
+&lt;/unitType&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="mass"/>
+      <xsd:enumeration value="length"/>
+      <xsd:enumeration value="time"/>
+      <xsd:enumeration value="current"/>
+      <xsd:enumeration value="amount"/>
+      <xsd:enumeration value="luminosity"/>
+      <xsd:enumeration value="temperature"/>
+      <xsd:enumeration value="dimensionless"/>
+      <xsd:enumeration value="angle">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">An angle (formally dimensionless, but useful to have units).</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="unitList" id="el.unitList">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A container for several unit entries</div>
+        <div class="description">Usually forms the complete units dictionary (along with metadata)</div>
+        <div class="example">
+          <pre>&lt;stm:unitList xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ========================= fundamental types =========================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unitType id="length" name="length"&gt;
+  &lt;stm:dimension name="length"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;stm:unitType id="time" name="time"&gt;
+  &lt;stm:dimension name="time"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unitType id="dimensionless" name="dimensionless"&gt;
+  &lt;stm:dimension name="dimensionless"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ========================== derived types ============================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unitType id="acceleration" name="acceleration"&gt;
+  &lt;stm:dimension name="length"/&gt;
+  &lt;stm:dimension name="time" power="-2"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ====================== fundamental SI units =========================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unit id="second" name="second" unitType="time"&gt;
+  &lt;stm:description&gt;The SI unit of time&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;stm:unit id="meter" name="meter" unitType="length"
+  abbreviation="m"&gt;
+  &lt;stm:description&gt;The SI unit of length&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unit id="kg" name="nameless" unitType="dimensionless"
+  abbreviation="nodim"&gt;
+  &lt;stm:description&gt;A fictitious parent for dimensionless units&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ===================== derived SI units ================================ --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unit id="newton" name="newton" unitType="force"&gt;
+  &lt;stm:description&gt;The SI unit of force&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;!-- multiples of fundamental SI units --&gt;
+
+&lt;stm:unit id="g" name="gram" unitType="mass"
+  parentSI="kg"
+  multiplierToSI="0.001"
+  abbreviation="g"&gt;
+  &lt;stm:description&gt;0.001 kg. &lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;stm:unit id="celsius" name="Celsius" parentSI="k"
+  multiplierToSI="1"
+  constantToSI="273.18"&gt;
+  &lt;stm:description&gt;&lt;p&gt;A common unit of temperature&lt;/p&gt;&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- fundamental non-SI units --&gt;
+
+&lt;stm:unit id="inch" name="inch" parentSI="meter"
+   abbreviation="in"
+  multiplierToSI="0.0254" &gt;
+  &lt;stm:description&gt;An imperial measure of length&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- derived non-SI units --&gt;
+
+&lt;stm:unit id="l" name="litre" unitType="volume"
+   parentSI="meterCubed"
+   abbreviation="l"
+   multiplierToSI="0.001"&gt;
+  &lt;stm:description&gt;Nearly 1 dm**3 This is not quite exact&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unit id="fahr" name="fahrenheit" parentSI="k"
+   abbreviation="F"
+  multiplierToSI="0.55555555555555555"
+  constantToSI="-17.777777777777777777"&gt;
+  &lt;stm:description&gt;An obsolescent unit of temperature still used in popular
+  meteorology&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;/stm:unitList&gt;
+</pre>
+        </div>
+        <div class="example">
+          <pre>&lt;stm:unitList
+    xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"
+    dictRef="unit" href="units.xml" /&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="unitType" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="unit" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="tit_id_conv_dictGroup"/>
+      <xsd:attribute name="href" type="xsd:anyURI">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">Maps a <a href="st.dictRefType">dictRef</a>
+            prefix to the location of a dictionary.</div>
+            <div class="description">This requires the prefix and the physical URI
+            address to be contained within the same file. We can anticipate that
+            better mechanisms will arise - perhaps through XMLCatalogs.
+            At least it works at present.</div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="unitType" id="el.unitType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An element containing the description of a scientific unit</div>
+        <div class="description">
+          <p>Mandatory for SI Units,
+          optional for nonSI units since they should be able to obtain this
+          from their parent. For complex derived units without parents it may be
+          useful.</p>
+          <p>Used within a unitList</p>
+          <p>Distinguish carefully from <a href="st.unitsType">unitsType</a>
+          which is primarily used for attributes describing the units that elements
+          carry</p>
+        </div>
+        <div class="example">
+          <pre>&lt;stm:unitList xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ========================= fundamental types =========================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unitType id="length" name="length"&gt;
+  &lt;stm:dimension name="length"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;stm:unitType id="time" name="time"&gt;
+  &lt;stm:dimension name="time"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unitType id="dimensionless" name="dimensionless"&gt;
+  &lt;stm:dimension name="dimensionless"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ========================== derived types ============================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unitType id="acceleration" name="acceleration"&gt;
+  &lt;stm:dimension name="length"/&gt;
+  &lt;stm:dimension name="time" power="-2"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ====================== fundamental SI units =========================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unit id="second" name="second" unitType="time"&gt;
+  &lt;stm:description&gt;The SI unit of time&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;stm:unit id="meter" name="meter" unitType="length"
+  abbreviation="m"&gt;
+  &lt;stm:description&gt;The SI unit of length&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unit id="kg" name="nameless" unitType="dimensionless"
+  abbreviation="nodim"&gt;
+  &lt;stm:description&gt;A fictitious parent for dimensionless units&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ===================== derived SI units ================================ --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unit id="newton" name="newton" unitType="force"&gt;
+  &lt;stm:description&gt;The SI unit of force&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;!-- multiples of fundamental SI units --&gt;
+
+&lt;stm:unit id="g" name="gram" unitType="mass"
+  parentSI="kg"
+  multiplierToSI="0.001"
+  abbreviation="g"&gt;
+  &lt;stm:description&gt;0.001 kg. &lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;stm:unit id="celsius" name="Celsius" parentSI="k"
+  multiplierToSI="1"
+  constantToSI="273.18"&gt;
+  &lt;stm:description&gt;&lt;p&gt;A common unit of temperature&lt;/p&gt;&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- fundamental non-SI units --&gt;
+
+&lt;stm:unit id="inch" name="inch" parentSI="meter"
+   abbreviation="in"
+  multiplierToSI="0.0254" &gt;
+  &lt;stm:description&gt;An imperial measure of length&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- derived non-SI units --&gt;
+
+&lt;stm:unit id="l" name="litre" unitType="volume"
+   parentSI="meterCubed"
+   abbreviation="l"
+   multiplierToSI="0.001"&gt;
+  &lt;stm:description&gt;Nearly 1 dm**3 This is not quite exact&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unit id="fahr" name="fahrenheit" parentSI="k"
+   abbreviation="F"
+  multiplierToSI="0.55555555555555555"
+  constantToSI="-17.777777777777777777"&gt;
+  &lt;stm:description&gt;An obsolescent unit of temperature still used in popular
+  meteorology&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;/stm:unitList&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="dimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="id" type="idType" use="required"/>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="unit" id="el.unit">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">A scientific unit</div>
+        <div class="description">
+          <p>A scientific unit. Units are of the following types:</p>
+          <ul>
+            <li>SI Units. These may be one of the seven fundamental types
+        (e.g. meter) or may be derived (e.g. joule). An SI unit is
+        identifiable because it has no parentSI attribute and will have
+        a unitType attribute.</li>
+            <li>nonSI Units. These will normally have a parent SI unit
+        (e.g. calorie has joule as an SI parent). </li>
+            <li/>
+          </ul>
+          <p>Example:</p>
+          <pre>
+&lt;unit id="units:fahr" name="fahrenheit" parentSI="units:K"
+  multiplierToSI="0.55555555555555555"
+  constantToSI="-17.777777777777777777"&gt;
+    &lt;description&gt;An obsolescent unit of temperature still used in popular
+      meteorology&lt;/description&gt;
+&lt;/unit&gt;
+
+        </pre>
+        </div>
+      </xsd:documentation>
+      <xsd:appinfo>
+
+      </xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="description"/>
+        <xsd:element ref="annotation"/>
+      </xsd:choice>
+      <xsd:attribute name="id" type="xsd:string" use="required"/>
+      <xsd:attribute name="abbreviation" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="parentSI" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">
+        A reference to the parent SI unit (forbidden for SI Units themselves).
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="unitType" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">
+        A reference to the unitType (required for SI Units).
+          </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="multiplierToSI" type="xsd:decimal" default="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">
+              <p>The factor by which the non-SI unit should be multiplied to
+        convert a quantity to its representation in SI Units.
+        This is applied <b>before</b>
+                <tt>constantToSI</tt>.
+        Mandatory for nonSI units; forbidden for SI units</p>
+            </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="constantToSI" type="xsd:decimal" default="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <div class="summary">
+              <p>The amount to add to a quantity in non-SI units to
+    convert its representation to SI Units.
+    This is applied <b>after</b>
+                <tt>multiplierToSI</tt>.
+    Optional for nonSI units; forbidden for SI units.
+  </p>
+            </div>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:simpleType name="unitsType" id="st.unitsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">Scientific units</div>
+        <div class="description">
+          <p>Scientific units. These will be linked to dictionaries of units with
+         conversion information, using namespaced references (e.g. <tt>si:m</tt>)
+          </p>
+          <p>Distinguish carefully from <a href="st.unitType">unitType</a>
+          which is an element describing a type of a unit in a <a href="el.unitList">unitList</a>
+          </p>
+        </div>
+        <div class="example">
+          <pre>&lt;stm:unitList xmlns:stm="http://www.xml-cml.org/schema/stmml-1.1"&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ========================= fundamental types =========================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unitType id="length" name="length"&gt;
+  &lt;stm:dimension name="length"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;stm:unitType id="time" name="time"&gt;
+  &lt;stm:dimension name="time"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unitType id="dimensionless" name="dimensionless"&gt;
+  &lt;stm:dimension name="dimensionless"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ========================== derived types ============================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unitType id="acceleration" name="acceleration"&gt;
+  &lt;stm:dimension name="length"/&gt;
+  &lt;stm:dimension name="time" power="-2"/&gt;
+&lt;/stm:unitType&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ====================== fundamental SI units =========================== --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unit id="second" name="second" unitType="time"&gt;
+  &lt;stm:description&gt;The SI unit of time&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;stm:unit id="meter" name="meter" unitType="length"
+  abbreviation="m"&gt;
+  &lt;stm:description&gt;The SI unit of length&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unit id="kg" name="nameless" unitType="dimensionless"
+  abbreviation="nodim"&gt;
+  &lt;stm:description&gt;A fictitious parent for dimensionless units&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ======================================================================= --&gt;
+&lt;!-- ===================== derived SI units ================================ --&gt;
+&lt;!-- ======================================================================= --&gt;
+
+&lt;stm:unit id="newton" name="newton" unitType="force"&gt;
+  &lt;stm:description&gt;The SI unit of force&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;!-- multiples of fundamental SI units --&gt;
+
+&lt;stm:unit id="g" name="gram" unitType="mass"
+  parentSI="kg"
+  multiplierToSI="0.001"
+  abbreviation="g"&gt;
+  &lt;stm:description&gt;0.001 kg. &lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;stm:unit id="celsius" name="Celsius" parentSI="k"
+  multiplierToSI="1"
+  constantToSI="273.18"&gt;
+  &lt;stm:description&gt;&lt;p&gt;A common unit of temperature&lt;/p&gt;&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- fundamental non-SI units --&gt;
+
+&lt;stm:unit id="inch" name="inch" parentSI="meter"
+   abbreviation="in"
+  multiplierToSI="0.0254" &gt;
+  &lt;stm:description&gt;An imperial measure of length&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- derived non-SI units --&gt;
+
+&lt;stm:unit id="l" name="litre" unitType="volume"
+   parentSI="meterCubed"
+   abbreviation="l"
+   multiplierToSI="0.001"&gt;
+  &lt;stm:description&gt;Nearly 1 dm**3 This is not quite exact&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;!-- ... --&gt;
+
+&lt;stm:unit id="fahr" name="fahrenheit" parentSI="k"
+   abbreviation="F"
+  multiplierToSI="0.55555555555555555"
+  constantToSI="-17.777777777777777777"&gt;
+  &lt;stm:description&gt;An obsolescent unit of temperature still used in popular
+  meteorology&lt;/stm:description&gt;
+&lt;/stm:unit&gt;
+
+&lt;/stm:unitList&gt;
+</pre>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string"/>
+  </xsd:simpleType>
+  <xsd:annotation>
+    <xsd:documentation>
+      <div class="heading">Groups (for schema maintenance and re-use)</div>
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:attributeGroup name="actionGroup" id="attGp.action">
+    <xsd:attribute name="start" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">The start time</div>
+          <div class="description">
+            <p>The start time in any allowable XSD representation of date, time or dateTime.
+          This will normally be a clock time or date.</p>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="startCondition" type="xsd:string"/>
+    <xsd:attribute name="duration" type="xsd:string"/>
+    <xsd:attribute name="end" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">The end time</div>
+          <div class="description">
+            <p>The start time in any allowable XSD representation of date, time or dateTime.
+          This will normally be a clock time or date.</p>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="endCondition" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">
+            <p>The end condition</p>
+          </div>
+          <div class="description">
+            <p>At present a human-readable string describing some condition when the
+          ac tion should end. As XML develops it may be possible to add machine-processable
+          semantics in this field.</p>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="units" type="unitsType">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">Units for the time attributes</div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="count" type="countType">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">Number of times the action should be repeated</div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+  <xsd:group name="dataGroup" id="gp.dataGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">
+          <p>A grouping of <tt>list</tt> and <tt>scalar</tt> elements for use by
+           other schemas. Experimental.</p>
+        </div>
+        <div class="description">
+          <p>This is to allow non-STM schemas to include a generic "data" component
+           in their elements. It is messy and probably should not survive. Better
+           extensibility mechanisms should be found.</p>
+          <p>Use only within Schemas</p>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice>
+      <xsd:element ref="list"/>
+      <xsd:element ref="scalar"/>
+    </xsd:choice>
+  </xsd:group>
+  <xsd:attributeGroup name="sourceGroup" id="attGp.source">
+    <xsd:attribute name="source" type="xsd:anyURI" id="att.source">
+      <xsd:annotation>
+        <xsd:documentation>
+          <div class="summary">An attribute linking to the source of the information</div>
+          <div class="description">
+            <p>A simple way of adding metadata to a piece of information.
+           Likely to be fragile since the URI may disappear.</p>
+          </div>
+          <div class="example">
+            <pre>
+&lt;list&gt;
+  &lt;definition source="foo.html#a3"&gt;An animal with four legs&lt;/definition&gt;
+  &lt;definition source="http://www.foo.com/index.html"&gt;
+    An animal with six legs&lt;/definition&gt;
+&lt;/list&gt;
+
+           </pre>
+          </div>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="tit_id_convGroup" id="attGp.tit_id_convGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">An group of attribute applicable to most STM-ML elements</div>
+        <div class="description">
+          <p>A group of attribute applicable to most STM-ML elements. It is
+        recommended that IDs are used widely. Titles have no semantics but
+        are useful for humans (e.g. a bond angle could be labelled "ortho"
+        or "gamma". Coventions are inherited by subelements; the default is the
+        current schema.</p>
+        </div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attributeGroup ref="idGroup"/>
+    <xsd:attributeGroup ref="titleGroup"/>
+    <xsd:attributeGroup ref="convGroup"/>
+  </xsd:attributeGroup>
+  <xsd:attributeGroup name="tit_id_conv_dictGroup" id="attGp.tit_id_conv_dictGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+        <div class="summary">Addition of the <tt>dictRef</tt> attribute to the <tt>tit_id_conv</tt> group.</div>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attributeGroup ref="tit_id_convGroup"/>
+    <xsd:attributeGroup ref="dictRefGroup"/>
+  </xsd:attributeGroup>
+  <xsd:attribute name="foo" type="xsd:string" id="att.foo345"/>
+</xsd:schema>

--- a/shinyApp/_infoBuilder/buildGuideline.R
+++ b/shinyApp/_infoBuilder/buildGuideline.R
@@ -1,8 +1,6 @@
 ### buildGuidelines.R ###
-rm(list=ls())
 start.time <- Sys.time()
-setwd(dirname(rstudioapi::getActiveDocumentContext()$path))
-
+cat("BUILDING GUIDELINES\n")
 
 
 ### libraries ###
@@ -47,42 +45,44 @@ cat("Producing the guidelines:\n")
 
 {
   ## system guideline ##
-  if(!file.exists( "../resources/systemGuideline.RData"))
+  # if(!file.exists( "../resources/systemGuideline.RData"))
   {
     cat("* System guideline: ")
     systemList = buildSystemList(files, focus)
     saveRDS(systemList, "../resources/systemGuideline.RData")
     cat(round(Sys.time() - start.time, 1),"s.\n"); start.time = Sys.time()
   }
-  else systemList <- readRDS("../resources/systemGuideline.RData")
+  # else systemList <- readRDS("../resources/systemGuideline.RData")
 
   ## Backbone guideline ##
-  if(!file.exists( "../resources/backboneGuideline.RData"))
+  # if(!file.exists( "../resources/backboneGuideline.RData"))
   {
     cat("* Backbone guideline: ")
     backboneList <- buildBackboneList(li = systemList, focus=focus)
     saveRDS(backboneList, "../resources/backboneGuideline.RData")
     cat(round(Sys.time() - start.time, 1),"s.\n")
   }
-  else backboneList <- readRDS("../resources/systemGuideline.RData")
+  # else backboneList <- readRDS("../resources/backboneGuideline.RData")
   
   ## Doc guideline ##
-  if(!file.exists( "../resources/docGuideline.RData"))
+  # if(!file.exists( "../resources/docGuideline.RData"))
   {
     cat("* Doc guideline: ")
     docList <- buildDocList(li = backboneList, filter = filter)
     saveRDS(docList, "../resources/docGuideline.RData")
     cat(round(Sys.time() - start.time, 1),"s.\n"); start.time = Sys.time()
   }
-  else docList <- readRDS("../resources/systemGuideline.RData")
+  # else docList <- readRDS("../resources/docGuideline.RData")
   
-  ## Fill guideline ##
-  {
-    cat("* Fill guideline: ")
-    fillList <- buildFillList(li = backboneList)
-    saveRDS(fillList, "../resources/fillGuideline.RData")
-    cat(round(Sys.time() - start.time, 1),"s.\n")
-  }
+  # ## Fill guideline ##
+  # if(!file.exists( "../resources/fillGuideline.RData"))
+  # {
+  #   cat("* Fill guideline: ")
+  #   fillList <- buildFillList(li = backboneList)
+  #   saveRDS(fillList, "../resources/fillGuideline.RData")
+  #   cat(round(Sys.time() - start.time, 1),"s.\n"); start.time = Sys.time()
+  # }
+  # else docList <- readRDS("../resources/fillGuideline.RData")
 }
 
 rm(list = ls())

--- a/shinyApp/_infoBuilder/buildIndex.R
+++ b/shinyApp/_infoBuilder/buildIndex.R
@@ -1,0 +1,24 @@
+# buildIndex.R
+cat("BUILDING INDEXES\n")
+
+# libraries
+library(data.tree)
+
+# imports
+source("guidelinesExplorer.R")
+
+
+# set vars
+{
+  cat("Setting variables\n")
+  xsdFiles = dir(path = "xsdFiles/", 
+                 pattern = "eml")
+  xsdFiles = paste0("xsdFiles/", xsdFiles)
+}
+
+# build index for namespaces
+{
+  cat("Indexing namespaces\n")
+  nsIndex <- buildNsIndex(xsdFiles)
+  saveRDS(nsIndex, "../resources/nsIndex.RData")
+}

--- a/shinyApp/_infoBuilder/buildResources.R
+++ b/shinyApp/_infoBuilder/buildResources.R
@@ -1,0 +1,9 @@
+# buildResources.R
+rm(list=ls())
+setwd(dirname(rstudioapi::getActiveDocumentContext()$path))
+
+
+
+# Imports
+source("buildGuideline.R", chdir = TRUE)
+source("buildIndex.R", chdir = TRUE)

--- a/shinyApp/_infoBuilder/guidelinesExplorer.R
+++ b/shinyApp/_infoBuilder/guidelinesExplorer.R
@@ -1,0 +1,20 @@
+# guidelinesExplorer.R
+
+# libraries
+library(XML)
+library(xml2)
+
+
+# This builds a dataframe indexing, for each namespace, the path
+# Needed to reach it in the docGuideline
+buildNsIndex <- function(files){
+  namespaces <- sapply(files, function(f){
+                         f.xml <- read_xml(f)
+                         return(xml_ns(f.xml))
+                       })
+  namespaces <- unlist(namespaces[!grepl("^d[0-9]*$", attr(namespaces, "names"))])
+  attr(namespaces, "names") <- gsub("^.*\\.","", attr(namespaces, "names"))
+  namespaces <- namespaces[!duplicated(attr(namespaces, "names"))]
+  namespaces <- namespaces[!grepl("d[0-9]+",attr(namespaces, "names"))]
+  return(namespaces)
+}

--- a/shinyApp/_infoBuilder/xsdExplorer.R
+++ b/shinyApp/_infoBuilder/xsdExplorer.R
@@ -4,7 +4,6 @@
 # on their official git (https://github.com/NCEAS/eml) on 2019/02/25
 
 # IMPORTS
-
 source("guidelinesFunctions.R")
 source("multiApply.R")
 source("../utils/followPath.R")
@@ -94,9 +93,9 @@ buildDocList <- function(li, filter)
 buildFillList <- function(li, focus, filter)
 { 
  
-  browser()
+  # browser()
   
-  return(fillList)
+  return(li)
 }
 
 

--- a/shinyApp/main.R
+++ b/shinyApp/main.R
@@ -3,6 +3,8 @@ rm(list = ls())
 setwd(dirname(rstudioapi::getActiveDocumentContext()$path))
 options(shiny.reactlog=TRUE)
 
+
+
 ### IMPORTS ###
 library(shiny)
 library(shinydashboard)
@@ -15,6 +17,7 @@ source("modules/welcome/welcome.R")
 if(!dir.exists(".cache/")) dir.create(".cache/")
 
 ### RESOURCES ###
+ns.index <- readRDS("resources/nsIndex.RData")
 
 # IM: Id Modules - first: session (=module namespace) - others: IDs
 IM.doc = c("docModule", "Documentation", "docSelect","docPath","docSearch")


### PR DESCRIPTION
In this update, MetaShARK adresses the question of the namespaces used in the XSD specification. It allows the user to browse the documentation from one module to another with links appearing as "Cf." in the documentation tabs.